### PR TITLE
docs: subagent model enforcement hook + context pruning routine

### DIFF
--- a/docs/cost-guide.md
+++ b/docs/cost-guide.md
@@ -256,3 +256,45 @@ ROI: 30-60x
 2. **Monthly:** Check your Anthropic dashboard for usage breakdown
 3. **Per-project:** Track sessions per project to identify high-cost areas
 4. **Optimize:** Review model routing monthly — are you using Opus where Sonnet would suffice?
+
+---
+
+## Context Pruning Routine
+
+Every session pays a fixed tax at startup for the skills registry, MCP tool schemas, slash commands, and hook output. That tax compounds as you install more plugins, MCP servers, and skills. Run a prune audit every 4-6 weeks to recover context budget.
+
+### What To Audit
+
+| Target | Command | What to look for |
+|:-------|:--------|:-----------------|
+| Skills registry size | Count `- <name>:` lines in the "The following skills are available" block | Above ~120 entries = regressed; investigate plugin sprawl |
+| Top-level MCP servers | `jq -r '.mcpServers \| keys[]' ~/.claude.json` | Remove servers you no longer use — each one injects tool schemas (~200-5,000 tokens) |
+| Per-project MCP servers | `jq -r '.projects \| to_entries[] \| select(.value.mcpServers) \| "\(.key): \(.value.mcpServers \| keys \| join(","))"' ~/.claude.json` | Same — scoped to project cwd, but still worth trimming |
+| Loose skills | `ls ~/.claude/skills/` | Archive unused skill directories to `~/.claude/_archive-prune-<date>/` |
+| Duplicate slash commands | `ls ~/.claude/commands/` | Delete user commands that duplicate installed plugin skills (e.g. `/commit` vs `commit-commands:commit`) |
+| SessionStart hooks | `jq '.hooks.SessionStart' ~/.claude/settings.json` | Every SessionStart hook runs on every new session — remove hooks whose script was archived |
+| Stale CC processes | `ps -eo pid,etime,command \| grep 'claude --allow-dangerously'` | Any session older than 4 hours MUST be `/clear`-ed or killed — sessions leak usage and orphan MCP subprocesses |
+| Claude.ai web connectors | `claude.ai/settings/connectors` | Disconnect integrations you don't actively use (Gmail, Calendar, Drive, Gamma, Excalidraw) |
+
+### What NOT to Prune
+
+Some context costs earn their keep. Do **not** archive the following in a routine prune:
+
+- **oh-my-claudecode (OMC).** OMC is the multi-agent orchestration backbone — its agent catalog, team runtime, skill registry, and hook/state wiring are load-bearing for any project using ralph, ultrawork, team, autopilot, or the `executor`/`planner`/`reviewer` subagent routing. Disabling OMC silently breaks orchestration skills that other playbook guidance assumes are available. Keep the plugin enabled globally; scope per-project via `enabledPlugins` in `~/.claude.json` only when you are certain no OMC-driven skill is invoked in that project.
+- **Your team's workflow hooks.** `ts-check.sh`, `pre-commit-verify.sh`, `codex-prepush-review.sh`, and equivalents catch regressions before they ship. Their per-run cost is negligible (see *Cost by Hook* above).
+- **CLAUDE.md layers.** Global, project, and local CLAUDE.md files are shared across every session — keep them tight (<150 instructions total across layers) but do not delete rules you still rely on.
+
+### Expected Savings
+
+A routine prune typically recovers **8-15k tokens per session start** in main contexts, plus the bigger win: killing stale >4-hour CC sessions that were burning API quota with no active work.
+
+### Archive Pattern
+
+Never delete outright. Move candidates to a dated archive so you can recover:
+
+```bash
+mkdir -p ~/.claude/_archive-prune-$(date +%Y%m%d)/{skills,commands,hooks}
+mv ~/.claude/skills/<unused-skill> ~/.claude/_archive-prune-$(date +%Y%m%d)/skills/
+```
+
+Keep archives for one review cycle, then delete if nothing was recovered.

--- a/docs/cost-guide.md
+++ b/docs/cost-guide.md
@@ -163,6 +163,24 @@ Agent(model: "sonnet", ...)  # implementation
 Agent(model: "opus", ...)    # architecture only
 ```
 
+#### Subagent model resolution order (verified against the claude binary)
+
+Prose rules are not enough. The binary resolves the subagent model in this order:
+
+1. `CLAUDE_CODE_SUBAGENT_MODEL` env var — overrides everything
+2. `model` param at `Agent`/`Task` invocation
+3. Agent frontmatter `model:` field
+4. Parent conversation model (default when nothing else is set)
+
+The footgun is step 4: when the model param is omitted and the agent has no frontmatter, the subagent inherits the parent (usually Opus). Every spawn silently multiplies the bill.
+
+Two enforcement paths (pick one or both):
+
+- **PreToolUse hook** (recommended — preserves per-agent overrides). Block `Agent`/`Task` calls that omit `model`. Reference implementation lives in [`hooks/require-agent-model.sh`](https://github.com/ao92265/claude-code-playbook/blob/main/hooks/require-agent-model.sh) in this repo. Wire it into `~/.claude/settings.json` under `hooks.PreToolUse` with matcher `"Agent|Task"`. The hook exits non-zero with an actionable error when `model` is missing, forcing Claude to retry with an explicit value. Set `REQUIRE_AGENT_MODEL_DISABLED=1` for an emergency bypass.
+- **Global env var floor.** Export `CLAUDE_CODE_SUBAGENT_MODEL=sonnet` in your shell profile. This overrides everything — simpler, impossible to bypass from the model side, but it erases per-agent overrides (an `opus` architect or `haiku` writer all collapse to sonnet).
+
+If you see subagents drift back to Opus after a week, the prose rule is being ignored in practice and the hook is the real fix. CLAUDE.md maintenance principle: if a rule is ignored across three sessions, delete it or convert it to a hook.
+
 ### 2. Context Management (Saves 10-20%)
 
 Polluted context = wasted tokens on irrelevant information.

--- a/hooks/README.md
+++ b/hooks/README.md
@@ -85,6 +85,17 @@ Add hook configurations to `~/.claude/settings.json`. Here's a complete example 
             "statusMessage": "Checking for protected files..."
           }
         ]
+      },
+      {
+        "matcher": "Agent|Task",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "~/.claude/hooks/require-agent-model.sh",
+            "timeout": 5,
+            "statusMessage": "Checking subagent model..."
+          }
+        ]
       }
     ],
     "PostToolUse": [
@@ -237,6 +248,20 @@ Prevents Claude from editing or writing to sensitive files (`.env`, lockfiles, P
 | **Matcher** | `Edit\|Write` |
 | **Catches** | Modifications to `.env*`, `package-lock.json`, `yarn.lock`, `pnpm-lock.yaml`, `prisma/schema.prisma` |
 | **Customizable** | Edit the `PROTECTED` array to add/remove paths |
+
+---
+
+### require-agent-model.sh
+
+Blocks `Agent`/`Task` tool calls that omit an explicit `model` field. Prevents subagents from silently inheriting the parent conversation model (usually Opus) and multiplying token spend. See [cost-guide.md → Smart Model Routing](../docs/cost-guide.md) for the full resolution order and rationale.
+
+| Property | Value |
+|----------|-------|
+| **Hook point** | `PreToolUse` |
+| **Matcher** | `Agent\|Task` |
+| **Catches** | `Agent(...)` / `Task(...)` invocations missing `model: "haiku\|sonnet\|opus"` |
+| **Requires** | `jq` on `PATH` (fails open if absent so it never bricks a session) |
+| **Bypass** | Export `REQUIRE_AGENT_MODEL_DISABLED=1` for a one-off, or set `CLAUDE_CODE_SUBAGENT_MODEL` globally to pin a model and short-circuit the hook |
 
 ---
 

--- a/hooks/require-agent-model.sh
+++ b/hooks/require-agent-model.sh
@@ -1,0 +1,57 @@
+#!/usr/bin/env bash
+# PreToolUse hook: block Agent tool calls missing an explicit `model` field.
+# Install by adding a PreToolUse matcher for "Agent" in settings.json that
+# points to this script. Without it, Claude inherits the parent model
+# (typically opus) into every subagent and burns ~5x the tokens.
+#
+# Exit codes:
+#   0   allow the call
+#   2   block (stderr shown to Claude as a tool-use error so it retries)
+#
+# Emergency override: set REQUIRE_AGENT_MODEL_DISABLED=1.
+
+set -euo pipefail
+
+if [[ "${REQUIRE_AGENT_MODEL_DISABLED:-0}" == "1" ]]; then
+  exit 0
+fi
+
+# If CLAUDE_CODE_SUBAGENT_MODEL is set, it overrides everything in the binary
+# resolution order, so the invocation param does not matter — allow the call.
+if [[ -n "${CLAUDE_CODE_SUBAGENT_MODEL:-}" ]]; then
+  exit 0
+fi
+
+payload="$(cat)"
+
+# If jq is unavailable, fail open rather than blocking everything.
+if ! command -v jq >/dev/null 2>&1; then
+  exit 0
+fi
+
+tool_name="$(jq -r '.tool_name // empty' <<<"$payload")"
+if [[ "$tool_name" != "Agent" && "$tool_name" != "Task" ]]; then
+  exit 0
+fi
+
+model="$(jq -r '.tool_input.model // empty' <<<"$payload")"
+subagent_type="$(jq -r '.tool_input.subagent_type // "<unset>"' <<<"$payload")"
+
+if [[ -z "$model" ]]; then
+  cat >&2 <<EOF
+Agent invocation is missing an explicit \`model\` field (subagent_type=$subagent_type).
+
+Without it, the subagent inherits the parent conversation model (typically
+opus), which silently multiplies token cost. Pick one:
+
+  - model: "haiku"   → file searches, formatting, boilerplate
+  - model: "sonnet"  → implementation, editing, tests, code review (default)
+  - model: "opus"    → architecture, hard debugging after >=2 sonnet passes
+
+Retry the call with \`model\` specified. To bypass this hook in an emergency,
+export REQUIRE_AGENT_MODEL_DISABLED=1 or set CLAUDE_CODE_SUBAGENT_MODEL.
+EOF
+  exit 2
+fi
+
+exit 0


### PR DESCRIPTION
## Summary
- Adds `hooks/require-agent-model.sh` — PreToolUse hook that blocks `Agent`/`Task` calls missing an explicit `model` field. Subagents silently inheriting the parent (usually Opus) multiplies spend; prose rules alone are not enforced.
- Documents the binary-verified subagent model resolution order in `docs/cost-guide.md` under Smart Model Routing: `CLAUDE_CODE_SUBAGENT_MODEL` env → invocation `model` → frontmatter → parent inheritance.
- Extends `hooks/README.md` with a wiring example (matcher `Agent|Task`) and an entry in the Included Hooks table.
- Prior commit on branch: context pruning routine + OMC flagged as non-prunable in `docs/cost-guide.md`.

## Test plan
- [x] `python3 -c "import json; json.load(open('~/.claude/settings.json'))"` → valid
- [x] Hook smoke tests: missing `model` → exit 2 with actionable stderr; `model: "sonnet"` present → exit 0; non-Agent tool → exit 0; `CLAUDE_CODE_SUBAGENT_MODEL` set → exit 0 (binary short-circuits); `jq` absent → fails open
- [x] Hook wired live in `~/.claude/settings.json` (PreToolUse, matcher `Agent|Task`)