### PR TITLE
docs(harness): add harness concept + audit-log hook from aidlc-workflows

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 
 <img src="https://img.shields.io/badge/29-Skills-8B5CF6?style=flat-square" alt="29 Skills"/>
 <img src="https://img.shields.io/badge/11-Templates-F97316?style=flat-square" alt="11 Templates"/>
-<img src="https://img.shields.io/badge/9-Hooks-EF4444?style=flat-square" alt="9 Hooks"/>
+<img src="https://img.shields.io/badge/10-Hooks-EF4444?style=flat-square" alt="10 Hooks"/>
 <img src="https://img.shields.io/badge/25-Docs-0078D4?style=flat-square" alt="25 Docs"/>
 <img src="https://img.shields.io/badge/3-Examples-22C55E?style=flat-square" alt="3 Examples"/>
 <img src="https://img.shields.io/badge/20-Anti--Patterns-EC4899?style=flat-square" alt="20 Anti-Patterns"/>
@@ -75,7 +75,7 @@ After months of daily production use — debugging at 2am, shipping features acr
 **Use**
 - [29 production-ready skills](skills/) (custom `/commands`) you can drop into any project
 - [11 CLAUDE.md templates + 1 team onboarding template](templates/) — TypeScript, React, Node, Python, Full-stack, Go, Rust, Mobile, DevOps, Java, C#, Team Onboarding
-- [9 hook scripts](hooks/) that catch errors before they reach your commits
+- [10 hook scripts](hooks/) that catch errors before they reach your commits
 - [3 annotated example sessions](examples/) showing real workflows in action
 - [MCP server guide](docs/mcp-servers.md), [skills ecosystem](docs/skills-ecosystem.md), [model comparison](docs/model-comparison.md), [workflow decision tree](docs/workflows.md), [20 anti-patterns](docs/anti-patterns.md), and [30-day usage insights](docs/usage-insights.md)
 - [CI/CD automation](docs/github-actions.md), [enterprise governance](docs/enterprise-governance.md), [agent teams](docs/agent-teams.md), [security remediation](docs/security-remediation.md), and [legacy modernization](docs/legacy-modernization.md)
@@ -184,6 +184,8 @@ claude-code-playbook/
 │   ├── local-models.md        # Gemma 4 (Apache 2.0) in Codex CLI via llama.cpp / Ollama
 │   ├── knowledge-and-context.md # Karpathy LLM Wiki pattern + 5-project ecosystem
 │   ├── bmad.md                # /bad autonomous sprint orchestrator deep dive
+│   ├── harness.md             # Harness vs model vs rules — what to build, what to use
+│   ├── audit-log-hook.md      # Raw-prompt compliance logging (aidlc-workflows pattern)
 │   └── news/                  # News & Research — 39 deep-read article pages (April 2026 research)
 ├── examples/
 │   ├── bug-fix-session.md     # Annotated bug fix session transcript
@@ -246,6 +248,7 @@ claude-code-playbook/
 │   ├── session-start-check.sh # Environment validation
 │   ├── firewall.sh            # Dangerous command blocker
 │   ├── protect-paths.sh       # Protected file guard
+│   ├── audit-log.sh           # Raw-prompt compliance log (UserPromptSubmit)
 │   └── README.md              # Hook setup guide
 ├── config/
 │   ├── settings-example.json  # Example settings.json
@@ -671,6 +674,8 @@ Never append to shared context files. Always replace the entire content and keep
 | **[Local Models](docs/local-models.md)** | Guide | Gemma 4 (Apache 2.0) as local model in Codex CLI (llama.cpp, Ollama) |
 | **[Knowledge & Context](docs/knowledge-and-context.md)** | Guide | Karpathy's LLM Wiki pattern + 5-project ecosystem (Waykee, Sage-Wiki, qmd) |
 | **[BMad Autonomous Development](docs/bmad.md)** | Guide | `/bad` overnight sprint orchestrator with git-worktree isolation |
+| **[Harness](docs/harness.md)** | Guide | Harness vs model vs rules: Claude Code, Agent SDK, and when to write rules instead |
+| **[Audit Log Hook](docs/audit-log-hook.md)** | Guide | Raw-prompt compliance logging adapted from awslabs/aidlc-workflows |
 | **[News & Research](docs/news/)** | 39 articles | Per-article deep reads of every substantive source behind the April 2026 briefing |
 | **[Article](article.md)** | Article | The original article that inspired this playbook |
 
@@ -763,9 +768,9 @@ sequenceDiagram
     Claude-->>You: "Bug fixed, types clean"
 ```
 
-**9 included hooks:** [ts-check.sh](hooks/ts-check.sh) (type errors) | [lint-check.sh](hooks/lint-check.sh) (ESLint) | [pre-commit-guard.sh](hooks/pre-commit-guard.sh) (debug statements) | [format-check.sh](hooks/format-check.sh) (Prettier) | [env-guard.sh](hooks/env-guard.sh) (secrets) | [build-check.sh](hooks/build-check.sh) (OOM-safe builds) | [session-start-check.sh](hooks/session-start-check.sh) (environment validation) | [firewall.sh](hooks/firewall.sh) (dangerous command blocker) | [protect-paths.sh](hooks/protect-paths.sh) (protected file guard)
+**10 included hooks:** [ts-check.sh](hooks/ts-check.sh) (type errors) | [lint-check.sh](hooks/lint-check.sh) (ESLint) | [pre-commit-guard.sh](hooks/pre-commit-guard.sh) (debug statements) | [format-check.sh](hooks/format-check.sh) (Prettier) | [env-guard.sh](hooks/env-guard.sh) (secrets) | [build-check.sh](hooks/build-check.sh) (OOM-safe builds) | [session-start-check.sh](hooks/session-start-check.sh) (environment validation) | [firewall.sh](hooks/firewall.sh) (dangerous command blocker) | [protect-paths.sh](hooks/protect-paths.sh) (protected file guard) | [audit-log.sh](hooks/audit-log.sh) (raw-prompt compliance log)
 
-> See **[hooks/README.md](hooks/README.md)** for setup and **[config/hooks-example.json](config/hooks-example.json)** for a complete configuration with all 9 hooks wired up.
+> See **[hooks/README.md](hooks/README.md)** for setup and **[config/hooks-example.json](config/hooks-example.json)** for a complete configuration with all 10 hooks wired up.
 
 <br/>
 

--- a/docs/audit-log-hook.md
+++ b/docs/audit-log-hook.md
@@ -1,0 +1,160 @@
+---
+title: Audit Log Hook
+nav_order: 41
+parent: Enterprise
+---
+# Audit Log Hook — Raw Prompt Logging For Compliance
+
+Pattern lifted from [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows), adapted to a Claude Code `UserPromptSubmit` hook. Every user prompt goes into a timestamped, append-only log. Useful when:
+
+- Regulated environment (SR 11-7, EU AI Act Article 12, ISO 42001) demands traceability of human → AI interactions
+- Post-incident forensics on agent behaviour
+- Billing/usage attribution inside a team
+- Debugging a session that went sideways and you want to replay the exact prompts
+
+---
+
+## What aidlc-workflows Does
+
+aidlc writes to `aidlc-docs/audit.md` with this format:
+
+```markdown
+## [Stage Name or Interaction Type]
+**Timestamp**: 2026-04-22T14:32:09Z
+**User Input**: "Complete raw user input — never summarized"
+**AI Response**: "AI's response or action taken"
+**Context**: Stage, action, or decision made
+
+---
+```
+
+Hard rules from their `core-workflow.md`:
+
+1. Capture user's **complete raw input** — never summarize or paraphrase
+2. **Always append**, never overwrite (tool calls that rewrite the whole file cause duplication)
+3. ISO 8601 timestamps
+4. Include stage context per entry
+
+Their workflow enforces this via a prose rule in `core-workflow.md`. Prose rules drift. A hook is deterministic.
+
+---
+
+## Claude Code Implementation
+
+### 1. The Hook Script
+
+Save as `~/.claude/hooks/audit-log.sh` (global) or `.claude/hooks/audit-log.sh` (per-project):
+
+```bash
+#!/usr/bin/env bash
+# Append every user prompt to an audit log with ISO 8601 timestamp.
+# Triggered by UserPromptSubmit hook. Never blocks input.
+
+set -u
+
+AUDIT_DIR="${CLAUDE_AUDIT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/audit}"
+AUDIT_FILE="${AUDIT_DIR}/prompts.md"
+
+mkdir -p "$AUDIT_DIR"
+
+# Hook payload arrives on stdin as JSON
+PAYLOAD="$(cat)"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // "unknown"')"
+CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // "unknown"')"
+PROMPT="$(printf '%s' "$PAYLOAD" | jq -r '.prompt // ""')"
+
+# Append-only. Never rewrite.
+{
+  printf '## Prompt\n'
+  printf '**Timestamp**: %s\n' "$TIMESTAMP"
+  printf '**Session**: `%s`\n' "$SESSION_ID"
+  printf '**Cwd**: `%s`\n' "$CWD"
+  printf '**User Input**:\n\n```\n%s\n```\n\n---\n\n' "$PROMPT"
+} >> "$AUDIT_FILE"
+
+# Exit 0 — never block the prompt
+exit 0
+```
+
+`chmod +x` it. `jq` required (ships with most dev machines; `brew install jq` on macOS).
+
+### 2. Wire It Up
+
+`.claude/settings.json`:
+
+```json
+{
+  "hooks": {
+    "UserPromptSubmit": [
+      {
+        "matcher": ".*",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/audit-log.sh"
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+Or global at `~/.claude/settings.json` with `command: "$HOME/.claude/hooks/audit-log.sh"`.
+
+### 3. Verify
+
+```bash
+# Start a session, type a prompt, then:
+cat .claude/audit/prompts.md
+```
+
+You should see the exact raw prompt logged with ISO timestamp and session id.
+
+---
+
+## Extending It — Responses, Tool Calls, Redaction
+
+**Log AI responses too** — add a `Stop` hook that appends a `## Response` block. Harder because `Stop` doesn't give you the final assistant text directly; the cleanest path is to tail the session transcript. Skip unless you actually need it.
+
+**Log tool calls** — add `PreToolUse` / `PostToolUse` hooks with `matcher: ".*"` to log tool name and input. Noisier. Good for debugging, bad for daily compliance volume.
+
+**Redaction for secrets** — pipe `$PROMPT` through a redactor before writing. Minimum: mask anything matching `(?i)(password|secret|token|api[_-]?key)\s*[:=]\s*\S+`. See [env-guard.sh](../hooks/env-guard.sh) for the same regex already used in this playbook for pre-commit scans.
+
+**Rotation** — `prompts.md` grows unbounded. Either:
+- Rotate daily: change `AUDIT_FILE` to `${AUDIT_DIR}/$(date -u +%Y-%m-%d).md`
+- Rotate by size: check `stat -f%z` and roll when > 10MB
+
+**Git-ignore or commit?** — depends. Commit only if prompts never contain secrets and your repo is internal. Default to `.gitignore` + upload to S3 / bucket from CI.
+
+---
+
+## Why Not Just Use Session Logs?
+
+Claude Code keeps session transcripts in `~/.claude/projects/<hash>/`. They contain the prompts. But:
+
+- Path is hash-based, hard to index by project / user / date
+- Format is JSONL internal schema, not designed for humans or auditors
+- No guarantee of retention policy — harness may compact or delete
+- Shared accounts (CI, service users) lose attribution
+
+The hook gives you a **project-local, human-readable, append-only, you-own-it** log. Auditors prefer that.
+
+---
+
+## When Not To Use This
+
+- Solo dev, non-regulated project → skip. Noise.
+- Already using OpenTelemetry / [cost-and-observability](cost-and-observability.md) stack → the OTel exporter captures prompts with more structure. Don't double-log.
+- Using Managed Agents / Bedrock / Vertex → the platform has its own audit trail. Check what it captures before adding this.
+
+---
+
+## Related
+
+- [regulated-ai.md](regulated-ai.md) — SR 11-7 / EU AI Act Article 12 context
+- [enterprise-governance.md](enterprise-governance.md) — Compliance API, managed policies
+- [hooks/README.md](../hooks/README.md) — hook authoring patterns
+- [harness.md](harness.md) — where hooks sit in the three-layer model

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -1,0 +1,168 @@
+---
+title: Harness
+nav_order: 40
+parent: Architecture
+---
+# Harness — What It Is, How To Implement
+
+"Harness" is the word that keeps showing up in AI-coding threads and nobody bothers defining it. It matters because the thing people call "Claude Code" is three layers stacked, and most confusion comes from conflating them.
+
+---
+
+## The Three Layers
+
+| Layer | Example | What it does |
+|:------|:--------|:------------|
+| Model | `claude-opus-4-7`, `claude-sonnet-4-6` | Generates tokens. Stateless. |
+| **Harness** | Claude Code, Cursor, Kiro, Copilot CLI, Agent SDK | Loop around the model: call → run tool → feed result back → repeat. Handles permissions, hooks, context compaction, subagents, sessions. |
+| Rules / skills | AGENTS.md, CLAUDE.md, [aidlc-workflows](https://github.com/awslabs/aidlc-workflows), OMC, BMAD | Prompts + workflow files injected *into* the harness to shape behavior. |
+
+**Rules files are not harnesses.** aidlc-workflows, OMC, BMAD — they all ride inside an existing harness (Claude Code, Kiro, Cursor). Same for skills in this playbook.
+
+The harness is the runtime that turns a single `messages.create` API call into an agentic session with file edits, shell commands, and recoverable state.
+
+---
+
+## Why The Distinction Matters
+
+When a teammate says "we need a harness", clarify which of these they actually want:
+
+1. **An agentic IDE/CLI to use day-to-day** → Claude Code, Cursor, Copilot, Kiro. Don't build. Configure.
+2. **Programmatic control over the agent loop** → Claude Agent SDK. Build on top.
+3. **Workflow rules to shape how the agent works** → AGENTS.md / CLAUDE.md / skills. Write rules, not code.
+4. **A custom agent loop from the bare API** → raw `messages.create` + tool dispatch. Only if SDK too opinionated. Usually wrong answer.
+
+90% of the time the ask is (1) or (3). People say "harness" when they mean "rules".
+
+---
+
+## Path 1 — Use The Existing Harness (Default)
+
+Claude Code **is** the harness. It ships with:
+
+- Tool-use loop (Read / Edit / Write / Bash / Task / etc.)
+- Permission prompts and allowlists (`.claude/settings.json`)
+- Hooks (PreToolUse, PostToolUse, UserPromptSubmit, SessionStart, Stop)
+- Subagents via `Agent` / `Task` tool
+- Context compaction (`/compact`, `/clear`)
+- Session persistence and resume
+
+Configure it with:
+- [`CLAUDE.md`](../templates/CLAUDE.md) — project rules
+- [`.claude/settings.json`](../config/settings-example.json) — permissions, env, hooks
+- [`.claude/hooks/`](../hooks/) — deterministic guardrails
+- [`.claude/skills/`](../skills/) — slash-command workflows
+
+**If you are asking "how do I implement a harness", this is the answer. Stop here unless you have a concrete reason to go further.**
+
+---
+
+## Path 2 — Build Custom With Claude Agent SDK
+
+Use when:
+- Agent embedded inside another app (not an IDE, not a CLI)
+- Headless CI/CD runs where you need programmatic start/stop
+- Custom tool whitelist (e.g. only allow SQL + HTTP, no shell)
+- Scheduled/triggered agents (cron, webhooks, queue workers)
+
+TypeScript:
+
+```bash
+npm install @anthropic-ai/claude-agent-sdk
+```
+
+```ts
+import { query } from "@anthropic-ai/claude-agent-sdk";
+
+const result = await query({
+  prompt: "Audit dependencies and open a PR if any are vulnerable.",
+  options: {
+    allowedTools: ["Read", "Grep", "Bash"],
+    maxTurns: 20,
+    permissionMode: "acceptEdits",
+  },
+});
+```
+
+Python:
+
+```bash
+pip install claude-agent-sdk
+```
+
+```python
+from claude_agent_sdk import query, ClaudeAgentOptions
+
+async for msg in query(
+    prompt="Audit deps and open a PR if any are vulnerable.",
+    options=ClaudeAgentOptions(
+        allowed_tools=["Read", "Grep", "Bash"],
+        max_turns=20,
+        permission_mode="acceptEdits",
+    ),
+):
+    print(msg)
+```
+
+SDK gives you the loop, tool dispatch, permission hooks, and MCP client. You wrap it with your trigger, storage, and UX.
+
+---
+
+## Path 3 — Write Rules, Not Code
+
+Most "build us a harness" requests are really "tell the agent how to behave". That's a rules problem, not a runtime problem.
+
+Rules layer options, ordered from lightest to heaviest:
+
+| Layer | Scope | Loaded | When |
+|:------|:------|:-------|:-----|
+| `CLAUDE.md` / `AGENTS.md` | Project | Every session | Always-on conventions (commit style, verification rules, change philosophy) |
+| `.claude/skills/<name>/SKILL.md` | Project or `~/.claude/skills/` global | On invocation (`/<name>` or auto-trigger) | Reusable workflows (deploy checklist, TDD loop) |
+| `.claude/hooks/*.sh` | Project or global | Deterministic events | Must-always-happen guardrails (type check, secret scan) |
+| Subagent frontmatter (`model:`, `tools:`) | Per agent | When agent invoked | Specialize per-role (reviewer, tester, executor) |
+
+Rule of thumb from this playbook:
+
+> Skills vs hooks: if it must **always** happen, write a hook. If it **usually** should, write a skill.
+
+See [path-scoped-rules.md](path-scoped-rules.md) for directory-scoped `CLAUDE.md` and [plugin-authoring.md](plugin-authoring.md) for packaging rules as a distributable plugin.
+
+---
+
+## Worked Example — aidlc-workflows
+
+[awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows) is the clearest public example of Path 3 done well.
+
+- Ships `core-workflow.md` (the entry rule) + `aidlc-rule-details/` (detail files loaded on demand)
+- Supports 7 harnesses out of the box: Kiro, Amazon Q, Cursor, Cline, Claude Code, Copilot, generic `AGENTS.md`
+- Uses `.opt-in.md` sidecar files to defer loading full rule bodies until the user consents (saves context)
+- Logs every user prompt raw into `aidlc-docs/audit.md` for compliance traceability
+- Gates every phase with a 2-option approval ("Request Changes | Continue")
+
+It is not a harness. It is a rules package that rides inside whatever harness you already use. Worth stealing patterns from — see [audit-log-hook.md](audit-log-hook.md) for the audit-log pattern adapted to Claude Code.
+
+---
+
+## Decision Checklist
+
+Before asking anyone to "build a harness", answer:
+
+- [ ] Can Claude Code + CLAUDE.md + skills + hooks do this? → Path 1. Done.
+- [ ] Do I need to embed the agent in a non-IDE context (webhook handler, CI job, internal service)? → Path 2, Agent SDK.
+- [ ] Am I really just describing a workflow the agent should follow? → Path 3, write rules.
+- [ ] Am I trying to reinvent tool-use / permissions / compaction? → Stop. Use the SDK.
+
+If the answer to all of these is no, you probably do not need a harness. You need a clearer prompt and a CLAUDE.md.
+
+---
+
+## FIS Defaults
+
+For Force Information Systems / Harris projects:
+
+- **Day-to-day dev**: Claude Code (this playbook's defaults)
+- **CI/CD**: Claude Code headless (`claude --print`) or Agent SDK in GitHub Actions — see [github-actions.md](github-actions.md)
+- **Compliance-audited projects**: Claude Code + [audit-log hook](audit-log-hook.md) for raw-prompt logging
+- **Multi-IDE teams**: ship rules as `AGENTS.md` (detected by Cursor, Copilot, Kiro, Cline) plus project-local `.claude/skills/`
+
+One harness per project. Pick it. Document it in the project README. Don't mix harnesses in the same working tree — permissions, hook paths, and state files collide.

--- a/hooks/audit-log.sh
+++ b/hooks/audit-log.sh
@@ -1,0 +1,47 @@
+#!/usr/bin/env bash
+# audit-log.sh — append every user prompt to a compliance log.
+#
+# Wire as UserPromptSubmit hook in .claude/settings.json:
+#   {
+#     "hooks": {
+#       "UserPromptSubmit": [
+#         { "matcher": ".*",
+#           "hooks": [{ "type": "command",
+#                       "command": "$CLAUDE_PROJECT_DIR/.claude/hooks/audit-log.sh" }] }
+#       ]
+#     }
+#   }
+#
+# Pattern adapted from awslabs/aidlc-workflows (aidlc-docs/audit.md).
+# See docs/audit-log-hook.md for context.
+
+set -u
+
+AUDIT_DIR="${CLAUDE_AUDIT_DIR:-${CLAUDE_PROJECT_DIR:-$PWD}/.claude/audit}"
+AUDIT_FILE="${AUDIT_DIR}/prompts.md"
+
+mkdir -p "$AUDIT_DIR"
+
+PAYLOAD="$(cat)"
+
+TIMESTAMP="$(date -u +%Y-%m-%dT%H:%M:%SZ)"
+
+if command -v jq >/dev/null 2>&1; then
+  SESSION_ID="$(printf '%s' "$PAYLOAD" | jq -r '.session_id // "unknown"')"
+  CWD="$(printf '%s' "$PAYLOAD" | jq -r '.cwd // "unknown"')"
+  PROMPT="$(printf '%s' "$PAYLOAD" | jq -r '.prompt // ""')"
+else
+  SESSION_ID="jq-missing"
+  CWD="$PWD"
+  PROMPT="$PAYLOAD"
+fi
+
+{
+  printf '## Prompt\n'
+  printf '**Timestamp**: %s\n' "$TIMESTAMP"
+  printf '**Session**: `%s`\n' "$SESSION_ID"
+  printf '**Cwd**: `%s`\n' "$CWD"
+  printf '**User Input**:\n\n```\n%s\n```\n\n---\n\n' "$PROMPT"
+} >> "$AUDIT_FILE"
+
+exit 0

--- a/hooks/audit-log.sh
+++ b/hooks/audit-log.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # audit-log.sh — append every user prompt to a compliance log.
 #
 # Wire as UserPromptSubmit hook in .claude/settings.json:

--- a/hooks/require-agent-model.sh
+++ b/hooks/require-agent-model.sh
@@ -1,4 +1,4 @@
-#!/usr/bin/env bash
+#!/bin/bash
 # PreToolUse hook: block Agent tool calls missing an explicit `model` field.
 # Install by adding a PreToolUse matcher for "Agent" in settings.json that
 # points to this script. Without it, Claude inherits the parent model


### PR DESCRIPTION
## Summary

- Adds `docs/harness.md` — kills the harness/model/rules buzzword confusion (three-layer model, decision checklist, FIS defaults, Claude Agent SDK path)
- Adds `docs/audit-log-hook.md` + `hooks/audit-log.sh` — ports the raw-prompt audit pattern from [awslabs/aidlc-workflows](https://github.com/awslabs/aidlc-workflows) into a deterministic `UserPromptSubmit` hook (append-only, ISO 8601, session/cwd metadata, works without `jq`)
- Updates README directory tree, docs table, and hook count (9 → 10)

## Why

Users hear "harness" and either freeze or try to build one when Claude Code already is one. Separately, aidlc-workflows' audit-log pattern is useful for FIS/regulated projects (SR 11-7 / EU AI Act Article 12) and the enforcement belongs in a hook, not prose.

## Test plan

- [x] `bash -n hooks/audit-log.sh` — syntax OK
- [x] End-to-end hook run with fake `UserPromptSubmit` JSON payload — writes correctly-formatted markdown block to `prompts.md`
- [x] Pre-commit CRLF check passed
- [ ] Reviewer sanity-checks the three-layer table and the SDK snippets
- [ ] Confirm README hook count / badge / tree still consistent

🤖 Generated with [Claude Code](https://claude.com/claude-code)