### PR TITLE
docs: add Tribune companion CLI

### DIFF
--- a/README.md
+++ b/README.md
@@ -649,6 +649,7 @@ Never append to shared context files. Always replace the entire content and keep
 | **[Workflows](docs/workflows.md)** | Guide | Decision tree: which skill to use for any situation |
 | **[Anti-Patterns](docs/anti-patterns.md)** | 20 items | The "don't do this" guide with real examples of what goes wrong |
 | **[Awesome Claude Code](docs/awesome-claude-code.md)** | List | Curated tools, plugins, MCP servers, and community resources |
+| **[Tribune](https://github.com/ao92265/tribune)** | Companion CLI | Convene a three-voice panel (Proposer / Skeptic / Red Team) on a hard decision and commit an ADR — uses your Claude Code / Codex / Gemini subscriptions, no API keys |
 | **[FAQ](docs/faq.md)** | Q&A | Quick answers to the most common questions |
 | **[Getting Started](docs/getting-started.md)** | Guide | Zero to productive in 10 minutes |
 | **[Team Setup](docs/team-setup.md)** | Guide | How to roll out the playbook to your team |

--- a/docs/awesome-claude-code.md
+++ b/docs/awesome-claude-code.md
@@ -21,6 +21,14 @@ A curated list of tools, plugins, MCP servers, and resources for Claude Code.
 | **[PR Review Toolkit](https://github.com/anthropics/claude-code-plugins)** | Comprehensive PR review with specialized analysis agents |
 | **[Commit Commands](https://github.com/anthropics/claude-code-plugins)** | Streamlined git commit, push, and PR workflows |
 
+## Companion CLIs
+
+CLI tools that wrap Claude Code (and sometimes Codex / Gemini) to extend its reach beyond a single session.
+
+| Tool | What It Does |
+|:-----|:------------|
+| **[Tribune](https://github.com/ao92265/tribune)** | Convenes three advocates — Proposer, Skeptic, Red Team — on a hard decision and commits the argument as an ADR. Runs off your Claude Code / Codex / Gemini CLI subscriptions, no API keys. Ships a `/tribune` slash command for Claude Code sessions. |
+
 ## MCP Servers
 
 See [docs/mcp-servers.md](mcp-servers.md) for detailed setup and configuration.


### PR DESCRIPTION
## Summary
- Add Tribune to `docs/awesome-claude-code.md` under a new Companion CLIs section
- Add Tribune row to the Documentation table in README.md

## Why
Tribune convenes a Proposer / Skeptic / Red Team panel on a decision and commits the argument as an ADR. Runs off Claude Code / Codex / Gemini CLI subscriptions (no API keys), ships a `/tribune` slash command, and fits the playbook's multi-model orchestration theme.

Repo: https://github.com/ao92265/tribune

## Test plan
- [x] Tribune link resolves
- [x] Diff limited to Tribune additions (README + awesome-claude-code.md)

🤖 Generated with [Claude Code](https://claude.com/claude-code)