### PR TITLE
docs(playbook): harness-pattern, steering-files, doc-finalise skill, prompt patterns 21/22

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,9 +24,9 @@
 <img src="https://img.shields.io/badge/29-Skills-8B5CF6?style=flat-square" alt="29 Skills"/>
 <img src="https://img.shields.io/badge/11-Templates-F97316?style=flat-square" alt="11 Templates"/>
 <img src="https://img.shields.io/badge/10-Hooks-EF4444?style=flat-square" alt="10 Hooks"/>
-<img src="https://img.shields.io/badge/25-Docs-0078D4?style=flat-square" alt="25 Docs"/>
+<img src="https://img.shields.io/badge/27-Docs-0078D4?style=flat-square" alt="27 Docs"/>
 <img src="https://img.shields.io/badge/3-Examples-22C55E?style=flat-square" alt="3 Examples"/>
-<img src="https://img.shields.io/badge/20-Anti--Patterns-EC4899?style=flat-square" alt="20 Anti-Patterns"/>
+<img src="https://img.shields.io/badge/22-Anti--Patterns-EC4899?style=flat-square" alt="22 Anti-Patterns"/>
 
 </div>
 
@@ -65,7 +65,7 @@ After months of daily production use — debugging at 2am, shipping features acr
 
 **Learn**
 - A [667-line power user guide](docs/guide.md) covering session management to multi-agent orchestration
-- [20 prompt engineering patterns](docs/prompt-patterns.md) with copy-paste examples and a decision tree
+- [22 prompt engineering patterns](docs/prompt-patterns.md) with copy-paste examples and a decision tree
 - [Quick-reference cheat sheet](docs/cheat-sheet.md) for commands, model routing, and session management
 - [Troubleshooting guide](docs/troubleshooting.md) with 15 common issues and diagnostic flowcharts
 
@@ -77,7 +77,7 @@ After months of daily production use — debugging at 2am, shipping features acr
 - [11 CLAUDE.md templates + 1 team onboarding template](templates/) — TypeScript, React, Node, Python, Full-stack, Go, Rust, Mobile, DevOps, Java, C#, Team Onboarding
 - [10 hook scripts](hooks/) that catch errors before they reach your commits
 - [3 annotated example sessions](examples/) showing real workflows in action
-- [MCP server guide](docs/mcp-servers.md), [skills ecosystem](docs/skills-ecosystem.md), [model comparison](docs/model-comparison.md), [workflow decision tree](docs/workflows.md), [20 anti-patterns](docs/anti-patterns.md), and [30-day usage insights](docs/usage-insights.md)
+- [MCP server guide](docs/mcp-servers.md), [skills ecosystem](docs/skills-ecosystem.md), [model comparison](docs/model-comparison.md), [workflow decision tree](docs/workflows.md), [22 anti-patterns](docs/anti-patterns.md), and [30-day usage insights](docs/usage-insights.md)
 - [CI/CD automation](docs/github-actions.md), [enterprise governance](docs/enterprise-governance.md), [agent teams](docs/agent-teams.md), [security remediation](docs/security-remediation.md), and [legacy modernization](docs/legacy-modernization.md)
 - [Skills 2.0](docs/skills-v2.md) (context fork, dynamic injection, agent frontmatter), [Code Container](docs/code-container.md) (Docker sandboxing), [auto mode](docs/auto-mode.md), [path-scoped rules](docs/path-scoped-rules.md), and [channels](docs/channels.md)
 - **One-line installer** for skills, hooks, and templates
@@ -150,13 +150,13 @@ graph TB
 claude-code-playbook/
 ├── docs/
 │   ├── guide.md               # The complete power user guide (667 lines)
-│   ├── prompt-patterns.md     # 20 prompt engineering patterns with examples
+│   ├── prompt-patterns.md     # 22 prompt engineering patterns with examples
 │   ├── cheat-sheet.md         # Quick-reference card for commands & workflows
 │   ├── troubleshooting.md     # 15 common issues with diagnostic flowcharts
 │   ├── mcp-servers.md         # MCP server guide: setup, token impact, troubleshooting
 │   ├── model-comparison.md    # Claude model comparison: Haiku vs Sonnet vs Opus
 │   ├── workflows.md           # Decision tree: which skill to use when
-│   ├── anti-patterns.md       # 20 things that go wrong and how to avoid them
+│   ├── anti-patterns.md       # 22 things that go wrong and how to avoid them
 │   ├── usage-insights.md      # 30-day field report: 2,228 sessions, top tools/MCPs/commands
 │   ├── awesome-claude-code.md # Curated list of tools, plugins, and resources
 │   ├── skills-ecosystem.md    # Agent skills package manager (skills.sh)
@@ -185,6 +185,8 @@ claude-code-playbook/
 │   ├── knowledge-and-context.md # Karpathy LLM Wiki pattern + 5-project ecosystem
 │   ├── bmad.md                # /bad autonomous sprint orchestrator deep dive
 │   ├── harness.md             # Harness vs model vs rules — what to build, what to use
+│   ├── harness-pattern.md     # The Harness Pattern — why vibe coding fails; three checks
+│   ├── steering-files.md      # Enforceable house rules for AI-generated code
 │   ├── audit-log-hook.md      # Raw-prompt compliance logging (aidlc-workflows pattern)
 │   └── news/                  # News & Research — 39 deep-read article pages (April 2026 research)
 ├── examples/
@@ -217,6 +219,7 @@ claude-code-playbook/
 │   ├── deep-explore/          # Deep codebase exploration
 │   ├── dependency-audit/      # Vulnerability & update audit
 │   ├── deploy/                # Safe deployment checklist
+│   ├── doc-finalise/          # Finalise .docx deliverables with embedded visuals + PDF regen
 │   ├── docker-check/          # Docker environment validation
 │   ├── executing-plans/       # Execute plans with checkpoints
 │   ├── explain/               # Layered code explanations
@@ -515,6 +518,7 @@ Every skill is a drop-in `/command` that teaches Claude a specific workflow. Cop
 | Skill | What It Does | When To Use |
 |:------|:------------|:------------|
 | **[changelog](skills/changelog/)** | Generates formatted changelog from recent commits (Keep a Changelog style) | Before releases or version tags |
+| **[doc-finalise](skills/doc-finalise/)** | Finalise .docx deliverables: integrity inventory, embedded PNG visuals, style normalisation, PDF regen, Closeout Trio summary | Board packs, exec status reports, compliance documents |
 | **[migrate-db](skills/migrate-db/)** | Safe database migration with backup verification, dry-run, and rollback plan | Running schema changes |
 | **[handoff](skills/handoff/)** | Structured session summary: what's done, what's left, decisions, gotchas | End of every session |
 | **[git-cleanup](skills/git-cleanup/)** | Clean up stale branches, prune remotes, tidy repository state | Periodic repo maintenance |
@@ -641,14 +645,15 @@ Never append to shared context files. Always replace the entire content and keep
 | | Doc | What It Covers |
 |:--|:----|:---------------|
 | **[Power User Guide](docs/guide.md)** | 667 lines | Full lifecycle: sessions, context, plugins, multi-agent, production lessons |
-| **[Prompt Patterns](docs/prompt-patterns.md)** | 459 lines | 20 patterns: Reverse Prompting, Constraint-First, Scope Lock, and more |
+| **[Prompt Patterns](docs/prompt-patterns.md)** | 531 lines | 22 patterns: Reverse Prompting, Constraint-First, Scope Lock, SOURCE FACTS / CHANGE LIST, The Closeout Trio, and more |
 | **[Cheat Sheet](docs/cheat-sheet.md)** | 192 lines | Quick-reference: commands, model routing, session management, troubleshooting |
 | **[Troubleshooting](docs/troubleshooting.md)** | 311 lines | 15 issues in Symptoms/Cause/Fix format with 3 diagnostic flowcharts |
 | **[MCP Servers](docs/mcp-servers.md)** | Guide | Setup, token impact, recommended servers, when to disable |
 | **[Model Comparison](docs/model-comparison.md)** | Guide | Haiku vs Sonnet vs Opus: routing, cost optimization, decision flowchart |
 | **[Workflows](docs/workflows.md)** | Guide | Decision tree: which skill to use for any situation |
-| **[Anti-Patterns](docs/anti-patterns.md)** | 20 items | The "don't do this" guide with real examples of what goes wrong |
+| **[Anti-Patterns](docs/anti-patterns.md)** | 22 items | The "don't do this" guide with real examples of what goes wrong |
 | **[Awesome Claude Code](docs/awesome-claude-code.md)** | List | Curated tools, plugins, MCP servers, and community resources |
+| **[Tribune](https://github.com/ao92265/tribune)** | Companion CLI | Convene a three-voice panel (Proposer / Skeptic / Red Team) on a hard decision and commit an ADR — uses your Claude Code / Codex / Gemini subscriptions, no API keys |
 | **[FAQ](docs/faq.md)** | Q&A | Quick answers to the most common questions |
 | **[Getting Started](docs/getting-started.md)** | Guide | Zero to productive in 10 minutes |
 | **[Team Setup](docs/team-setup.md)** | Guide | How to roll out the playbook to your team |
@@ -675,6 +680,8 @@ Never append to shared context files. Always replace the entire content and keep
 | **[Knowledge & Context](docs/knowledge-and-context.md)** | Guide | Karpathy's LLM Wiki pattern + 5-project ecosystem (Waykee, Sage-Wiki, qmd) |
 | **[BMad Autonomous Development](docs/bmad.md)** | Guide | `/bad` overnight sprint orchestrator with git-worktree isolation |
 | **[Harness](docs/harness.md)** | Guide | Harness vs model vs rules: Claude Code, Agent SDK, and when to write rules instead |
+| **[Harness Pattern](docs/harness-pattern.md)** | Play | Why vibe coding fails: three checks (steering, content store, comprehension), anti-patterns, agent hardening |
+| **[Steering Files](docs/steering-files.md)** | Guide | Writing enforceable house rules: good-vs-bad rule test, nested CLAUDE.md, minimum viable checklist |
 | **[Audit Log Hook](docs/audit-log-hook.md)** | Guide | Raw-prompt compliance logging adapted from awslabs/aidlc-workflows |
 | **[News & Research](docs/news/)** | 39 articles | Per-article deep reads of every substantive source behind the April 2026 briefing |
 | **[Article](article.md)** | Article | The original article that inspired this playbook |

--- a/docs/anti-patterns.md
+++ b/docs/anti-patterns.md
@@ -229,6 +229,18 @@ These are the most common mistakes from 900+ sessions. Each one has burned real 
 
 ---
 
+## Document Anti-Patterns
+
+### 22. Silent Conflict Resolution
+
+**Don't:** Quietly pick one number when the appendix table and the prose disagree.
+
+**Why it fails:** When two data sources in the same artefact disagree, the model's default is to pick one and normalise. That erases a real conflict the author needs to resolve. "Trust the appendix table" is a specific rule the author can choose to apply. "Silently use the smaller number" is a rule nobody chose. The written-document equivalent of "the tests pass so it's fine" — the output looks coherent, which is precisely why the bug survives review.
+
+**Do instead:** Flag the conflict, state which source you used and why, and surface the decision in the closeout under "what needs your eyes" (see [prompt-patterns.md §22 The Closeout Trio](prompt-patterns.md#22-the-closeout-trio)). Leave the resolution visible so the author can choose — don't resolve it on their behalf.
+
+---
+
 ## Quick Reference
 
 | # | Anti-Pattern | Fix |
@@ -254,3 +266,4 @@ These are the most common mistakes from 900+ sessions. Each one has burned real 
 | 19 | No CLAUDE.md | Copy a template from this playbook |
 | 20 | Stale lessons | Review and prune monthly |
 | 21 | Cognitive debt | Spec → scoped tasks → PR review → test. Governance is the product |
+| 22 | Silent conflict resolution | Flag the conflict, don't resolve it. Surface in the Closeout Trio |

--- a/docs/awesome-claude-code.md
+++ b/docs/awesome-claude-code.md
@@ -21,6 +21,14 @@ A curated list of tools, plugins, MCP servers, and resources for Claude Code.
 | **[PR Review Toolkit](https://github.com/anthropics/claude-code-plugins)** | Comprehensive PR review with specialized analysis agents |
 | **[Commit Commands](https://github.com/anthropics/claude-code-plugins)** | Streamlined git commit, push, and PR workflows |
 
+## Companion CLIs
+
+CLI tools that wrap Claude Code (and sometimes Codex / Gemini) to extend its reach beyond a single session.
+
+| Tool | What It Does |
+|:-----|:------------|
+| **[Tribune](https://github.com/ao92265/tribune)** | Convenes three advocates — Proposer, Skeptic, Red Team — on a hard decision and commits the argument as an ADR. Runs off your Claude Code / Codex / Gemini CLI subscriptions, no API keys. Ships a `/tribune` slash command for Claude Code sessions. |
+
 ## MCP Servers
 
 See [docs/mcp-servers.md](mcp-servers.md) for detailed setup and configuration.

--- a/docs/harness-pattern.md
+++ b/docs/harness-pattern.md
@@ -1,0 +1,189 @@
+---
+title: The Harness Pattern
+nav_order: 41
+parent: Architecture
+---
+# The Harness Pattern (and Why Vibe Coding Fails)
+
+> The model is not the product. The harness around it is. — paraphrased from every third talk at AWS Summit London 2026
+
+Most AI-assisted code review failures are not model failures. They are harness failures. This play captures the lessons that apply directly to Claude Code workflows: how to wrap the model in rules so it produces code your team can actually own.
+
+For the layered definition of model / harness / rules and the four decision paths (Claude Code vs Agent SDK vs rules vs bare API), see [harness.md](harness.md). This play is the narrative companion — why the harness matters and how to tighten it when AI-generated code has to live in a codebase someone will still be maintaining next year.
+
+---
+
+## What a Project-Level Harness Is
+
+A harness is everything around the model that decides what it can see, what it can do, what it must refuse, and how you prove afterwards that it behaved. In Claude Code terms, the harness is:
+
+- Your `CLAUDE.md` and steering files
+- The skills, tools and MCP servers you allow
+- The content store the model can retrieve from
+- The pre-commit hooks, code reviews and eval loops around the output
+- The boundary between "Claude can touch this" and "Claude must not touch this"
+
+Claude Code is already a harness around a raw LLM. The question this play answers is: how do you make your *project-level* harness good enough that Claude can help you modernise a legacy system without silently burying the team in debt?
+
+---
+
+## The Three Checks
+
+From Owen Hawkins' CDL talk at AWS Summit London 2026. These belong on every PR description that contains AI-generated code.
+
+1. **Steering.** Are your standards and practices enforced by files the model has to read, not folklore? If the answer is "we told it once in the prompt," that's not enforcement.
+2. **Content store.** Can the model ground its changes in your actual code, docs and decisions, or is it working from training data and guesswork?
+3. **Comprehension.** Can a human on the team read the generated code, explain it, and defend it in review? If not, do not merge it.
+
+> "It compiles and the tests pass" is not the bar. "A human on this team can read it, explain it, and maintain it" is the bar.
+
+---
+
+## Steering Files: Rules, Not Vibes
+
+A steering file is a set of house rules the model must code within. They are not suggestions. Put these in `CLAUDE.md` at the repo root:
+
+- Language and framework versions (and which ones are banned)
+- Allowed libraries and the reasoning (one line each)
+- Architectural patterns and layering rules (what calls what)
+- Test expectations (coverage target, framework, what must be mocked)
+- House style points the linter cannot catch (naming, error handling shape, logging)
+- Explicit "do not" list: deprecated APIs, libraries on the removal path, patterns from the legacy system that must not be reproduced
+
+**Good steering rule:**
+
+```
+All new code must use the Result<T, E> return pattern for fallible operations.
+Do not throw exceptions from service-layer functions. See docs/error-handling.md.
+```
+
+**Bad steering rule:**
+
+```
+Write clean code.
+```
+
+The difference is enforceability. The first can be checked in review. The second cannot.
+
+**When to nest `CLAUDE.md` files.** One at the repo root for repo-wide rules. A second inside `services/payments/` for payments-specific rules (PII handling, audit logging, idempotency). Claude Code reads the closest one first. See [path-scoped-rules.md](path-scoped-rules.md) for directory-scoped loading order.
+
+Deeper treatment: [steering-files.md](steering-files.md).
+
+---
+
+## Add a Content Store
+
+If the model is guessing at your codebase, it will produce confident wrong answers. Give it somewhere to look.
+
+Practical minimum for a modernisation project:
+
+- An `ARCHITECTURE.md` that actually describes the current shape of the system
+- A `DECISIONS/` folder of short ADRs (one per non-obvious choice)
+- A `GLOSSARY.md` that defines domain terms, especially when migrating from a legacy system with its own vocabulary
+- The legacy source, searchable, so the model can check "how did the old system do this?" before re-inventing behaviour
+- Tests as executable documentation of expected behaviour
+
+Claude Code + `Grep` across these is already a usable retrieval harness. MCP servers (Context7 for library docs, an internal-docs MCP for company knowledge) extend it further without blowing up the context window. See [mcp-servers.md](mcp-servers.md) and [knowledge-and-context.md](knowledge-and-context.md) for the retrieval side.
+
+---
+
+## The Comprehension Check (Anti-Vibe-Coding)
+
+The single biggest risk in AI-assisted modernisation is that the pipeline produces code that works, no one on the team understands, and nobody is willing to touch in six months. This is vibe coding: shipping what the model produced because the vibes were right.
+
+Stop it at review. Before merging AI-assisted code, the author must be able to answer, **in writing in the PR description**:
+
+- What does this code do, in one paragraph, in your own words?
+- Why this approach rather than the obvious alternative?
+- Where would you put a breakpoint if it misbehaved in prod?
+- What's the blast radius if this is wrong?
+
+If any answer is "I'd ask Claude," the PR is not ready.
+
+---
+
+## Anti-Patterns
+
+| Anti-pattern | Why it fails | Fix |
+|---|---|---|
+| "The tests pass so it's fine" | Tests were also generated by the model; they test what was built, not what was needed | Write or review the tests against the requirement, not the implementation |
+| Copy-paste-accept | Author cannot explain the code in review | Require a written explanation in the PR description |
+| No steering file | Every change is a new negotiation with the model | Put the negotiation on disk, where it's versioned |
+| "It compiles" as the bar | Compilation proves nothing about correctness | Raise the bar — comprehension + behaviour, not syntax |
+| One giant generated PR | Impossible to review; incentive to rubber-stamp | Cap generated PR size; one bounded change at a time |
+| Self-reviewed AI output | No independent signal | Human review of AI PRs is non-negotiable, and not by the person who drove the generation |
+
+---
+
+## Don't Mark Your Own Homework
+
+Evaluations live outside the system being tested. If the same pipeline that generated the code also judged the code, you have no independent signal.
+
+For a modernisation project that means:
+
+- Property-based tests and contract tests written against the **original** behaviour, not the new implementation
+- A separate test harness that replays real inputs through old and new code and compares outputs
+- Code review by someone who didn't drive the generation
+- Static analysis (linters, type checkers) as a disinterested third party
+
+For teams building AI features, the same rule applies at runtime: the eval harness must be a separate service, with a separate prompt, ideally a different model. Do not ask the generating model whether its output was correct.
+
+---
+
+## For Anyone Building Agents on Top of Claude
+
+Most of the chatbot-hardening lessons from the Summit lift one-for-one to Claude-based agents:
+
+- **Scoped tool-calling.** The agent can only call a short, explicit tool list. If the model tries something else, the harness rejects the turn.
+- **PII minimisation at the boundary.** Redact before the model sees it. Re-hydrate after.
+- **Refusal as first-class behaviour.** Evaluate whether the agent refused appropriately, not just whether it answered.
+- **Policy trigger-rate drift alerts.** When a guardrail suddenly fires twice as often, treat it as a production signal.
+- **Canary prompts.** A handful of known-good and known-bad prompts injected continuously.
+- **Persuasion-style red teaming.** Not just "abuse" prompts — social-engineering ones. The Zeng et al. jailbreak paper (below) gives a starting taxonomy (harmful prompts × persuasion strategies).
+- **Version prompts and tools like code.** Roll them back independently from the model.
+- **Structured tracing on every LLM turn.** Guardrail decisions, prompt, output and downstream calls in one trace.
+
+See [regulated-ai.md](regulated-ai.md) for SR 11-7 / EU AI Act alignment and [cost-and-observability.md](cost-and-observability.md) for the tracing stack.
+
+---
+
+## Decision Tree — Harness, Rules, or Step Back?
+
+```
+Generating code for a new, low-stakes feature?
+ └─ Steering file + PR review is probably enough.
+
+Generating code that touches auth, payments, customer data, or safety?
+ └─ Steering file + content store + scoped tools + named human reviewer.
+    Generated code must come with a written comprehension note.
+
+Generating code to replace a legacy system (VB6, COBOL, monolith)?
+ └─ All of the above, plus:
+    - Replay harness comparing old vs new behaviour on real inputs
+    - No "big bang" PRs — one bounded capability at a time
+    - ADR for every non-obvious migration decision
+    - Independent review by someone who did not drive the generation
+
+No one on the team can read the generated output?
+ └─ Stop. The harness is too loose or the task is too big.
+    Tighten steering, shrink the scope, or step back from AI assistance
+    for this slice.
+```
+
+---
+
+## Sources
+
+- Owen Hawkins, *Lessons Learnt from CDL: Avoid Vibe Coding* — AWS Summit London, 22 April 2026
+- Virgin Atlantic, *Building Concierge* (voice + text LLM concierge, OpenAI + LiveKit + Datadog LLMObs) — AWS Summit London, 22 April 2026
+- Zeng et al., *How Johnny Can Persuade LLMs to Jailbreak Them* — referenced as the basis for Virgin Atlantic's persuasion red-team set
+
+---
+
+## See Also
+
+- [harness.md](harness.md) — model / harness / rules layers and the four implementation paths
+- [steering-files.md](steering-files.md) — writing enforceable house rules
+- [templates/CLAUDE.md](../templates/CLAUDE.md) — starting point for a steering file
+- [skills/code-review/](../skills/code-review/) — structured review skill; pair with the comprehension check
+- [legacy-modernization.md](legacy-modernization.md) — characterisation tests and incremental migration

--- a/docs/prompt-patterns.md
+++ b/docs/prompt-patterns.md
@@ -18,6 +18,7 @@ graph TD
     START --> REFACTOR{"Refactoring?"}
     START --> ARCH{"Architecture?"}
     START --> UI{"UI work?"}
+    START --> DOC{"Document?"}
 
     BUG --> |"Yes"| B1["Smallest Failing Test"]
     BUG --> |"Complex"| B2["Rubber Duck Debugging"]
@@ -35,6 +36,9 @@ graph TD
     UI --> |"Mockup"| U1["Screenshot-Driven UI"]
     UI --> |"From scratch"| U2["Reference Implementation"]
 
+    DOC --> |"Finalise"| D1["SOURCE FACTS / CHANGE LIST"]
+    DOC --> |"Handoff deliverable"| D2["The Closeout Trio"]
+
     style START fill:#4A90D9,stroke:#357ABD,color:#fff
     style B1 fill:#50C878,stroke:#3CB371,color:#fff
     style B2 fill:#50C878,stroke:#3CB371,color:#fff
@@ -47,6 +51,8 @@ graph TD
     style A2 fill:#FF6B6B,stroke:#EE5A5A,color:#fff
     style U1 fill:#DDA0DD,stroke:#BA55D3,color:#333
     style U2 fill:#DDA0DD,stroke:#BA55D3,color:#333
+    style D1 fill:#14B8A6,stroke:#0F766E,color:#fff
+    style D2 fill:#14B8A6,stroke:#0F766E,color:#fff
 ```
 
 ---
@@ -388,6 +394,67 @@ Save this to SESSION_NOTES.md so the next session can pick up cleanly.
 ```
 
 **Why it works:** Context doesn't survive between sessions. A structured handoff preserves decisions, progress, and warnings that would otherwise be lost, preventing the next session from repeating work or making contradictory choices.
+
+---
+
+### 21. SOURCE FACTS / CHANGE LIST
+
+**When to use:** Finalising a document where factual accuracy and preservation both matter — executive status reports, regulatory and compliance documents, second-pass edits where "tighten this up" has historically rephrased a number into an inaccuracy.
+
+```
+You are finalising [artefact type] for [audience].
+
+Rewrite the DRAFT to apply every item in CHANGE LIST,
+preserving every substantive fact in SOURCE FACTS.
+
+OUTPUT RULES
+- [style, length, tone, forbidden constructs]
+
+CHANGE LIST, fix every one of these
+1. [specific directive]
+2. [specific directive]
+...
+
+SOURCE FACTS, use these, do not round them
+[structured authoritative data, tables, counts]
+
+DRAFT
+[current draft, or state "no draft, build from facts"]
+```
+
+**Why it works:** The model treats the current draft as authoritative by default and preserves its language patterns, including the inaccuracies. Separating facts from instructions prevents rounding drift, lost caveats, and hallucinated middle-ground values where `SOURCE FACTS` has the exact number.
+
+**Gotcha:** if the draft placeholder is empty, say so explicitly. The model will silently proceed from `SOURCE FACTS` alone, which is usually fine but occasionally loses phrasing that had already been socialised. Distinct from [Constraint-First (§2)](#2-constraint-first) — that locks scope; this locks facts.
+
+---
+
+### 22. The Closeout Trio
+
+**When to use:** Handing back any substantive deliverable — written document, mixed output, research note. Per-deliverable, not per-session.
+
+```
+End every substantive deliverable with three sections:
+
+1. What I did
+   Concrete, checkable facts. Paragraph counts before and after.
+   File sizes. Page counts. Not "I updated the document" but
+   "98 paragraphs became 108 paragraphs, +10 from two five-element chart blocks."
+
+2. What I could not do and why
+   Explicit capability boundaries. "I cannot reach your local repo,
+   so I produced the four files and a paste-ready commit block."
+   This is where you catch the model trying to hide a gap.
+
+3. What needs your eyes
+   Things the model cannot adjudicate: pre-existing data tension between
+   two sources, cosmetic layout questions, numbers that look right but
+   need a human ticking them off, anything that touched a
+   "don't change X" constraint.
+```
+
+**Why it works:** Without this closeout, the model optimises for appearing-done. With it, the model optimises for being-reliable. The numeric specifics in "what I did" make it harder to fabricate completion. "What I could not do" normalises admitting capability gaps so the model stops papering over them. Paired with [Silent Conflict Resolution anti-pattern (§22)](anti-patterns.md#22-silent-conflict-resolution) for the written-deliverable equivalent of "the tests pass so it's fine".
+
+**Scope vs related material:** [skills/verification-before-completion/](../skills/verification-before-completion/) is the code-side equivalent — run the tests, paste the output. This is the version for writing and mixed outputs where "does it compile" is not the check. [skills/handoff/](../skills/handoff/) is session-end summary; this is per-deliverable — different scope.
 
 ---
 

--- a/docs/steering-files.md
+++ b/docs/steering-files.md
@@ -1,0 +1,95 @@
+---
+title: Steering Files
+nav_order: 42
+parent: Architecture
+---
+# Steering Files
+
+A steering file is a set of house rules the model must code within. Not suggestions. Not folklore. Rules the model has to read every session, that a reviewer can point at when the PR violates them.
+
+For the wider harness framing (why steering matters alongside a content store and a comprehension check) see [harness-pattern.md](harness-pattern.md).
+
+---
+
+## The Enforceability Test
+
+If a rule can't be checked in review, it's not a rule. It's a wish.
+
+**Good steering rule:**
+
+```
+All new code must use the Result<T, E> return pattern for fallible operations.
+Do not throw exceptions from service-layer functions. See docs/error-handling.md.
+```
+
+**Bad steering rule:**
+
+```
+Write clean code.
+```
+
+One is enforceable. The other is a vibe.
+
+---
+
+## What Belongs in a Steering File
+
+Put these in `CLAUDE.md` at the repo root:
+
+- **Language and framework versions** — and which ones are banned
+- **Allowed libraries** — each with a one-line reason
+- **Architectural patterns** — layering rules (what calls what)
+- **Test expectations** — coverage target, framework, what must be mocked, what must not
+- **House style the linter cannot catch** — naming shape, error-handling shape, logging shape
+- **Explicit "do not" list** — deprecated APIs, libraries on the removal path, legacy patterns that must not be reproduced
+
+Things that do **not** belong: general programming advice ("write good code"), platitudes, duplicated linter rules, anything that would apply to every project on earth.
+
+---
+
+## Minimum Viable Steering File
+
+If you're starting from zero, copy [templates/CLAUDE.md](../templates/CLAUDE.md) or the stack-specific variant, then fill in:
+
+- [ ] Language version + framework version + banned alternates
+- [ ] Test command and how to run a single test
+- [ ] Error-handling shape (exceptions vs Result-type vs error returns)
+- [ ] One example of the naming convention you expect
+- [ ] At least one "do not" rule specific to your codebase
+- [ ] A link to the content store (ARCHITECTURE.md, ADRs, glossary)
+
+Six bullets is enough to start. You will add more as you catch the model doing things you didn't want.
+
+---
+
+## Nested `CLAUDE.md` — When to Split
+
+One at the repo root for repo-wide rules. A second inside a subdirectory when that area has rules the rest of the repo doesn't share.
+
+Examples that justify a nested file:
+
+- `services/payments/CLAUDE.md` — PII handling, audit logging, idempotency requirements
+- `packages/ui/CLAUDE.md` — component conventions, accessibility rules, Storybook coverage
+- `infra/terraform/CLAUDE.md` — state locking, backend config, naming of IAM resources
+
+Claude Code reads the closest `CLAUDE.md` first, then walks up. See [path-scoped-rules.md](path-scoped-rules.md) for directory-scoped loading order and override semantics.
+
+---
+
+## Keeping Steering Files Alive
+
+A steering file that nobody updates rots. Rot manifests as: the model ignores rules that no longer match the codebase; reviewers stop quoting the file in PR comments; new team members ask questions the file was supposed to answer.
+
+Two habits keep them alive:
+
+- **Quote the file in every AI-PR review comment.** "This violates CLAUDE.md §3 — wrap the API call in our `tryCall` helper." The file earns its keep when it's the thing reviewers point at.
+- **Prune monthly.** Delete rules that no longer apply. Update rules whose context has changed. See [anti-patterns.md §20](anti-patterns.md) on stale lessons.
+
+---
+
+## Related
+
+- [harness-pattern.md](harness-pattern.md) — why steering is one of the three checks
+- [path-scoped-rules.md](path-scoped-rules.md) — directory-scoped `CLAUDE.md` loading
+- [templates/CLAUDE.md](../templates/CLAUDE.md) — starting point, 12 sections
+- [prompt-discipline.md](prompt-discipline.md) — authority language (`MUST`, `WILL`, `NEVER`) and why `should/consider/try` weakens enforcement

--- a/onboarding/05-advanced.md
+++ b/onboarding/05-advanced.md
@@ -116,10 +116,10 @@ See [CONTRIBUTING.md](../CONTRIBUTING.md) for the format.
 | Topic | Resource |
 |:------|:---------|
 | All 27 skills | [Workflow decision tree](../docs/workflows.md) |
-| Common mistakes | [20 anti-patterns](../docs/anti-patterns.md) |
+| Common mistakes | [22 anti-patterns](../docs/anti-patterns.md) |
 | Model selection | [Model comparison](../docs/model-comparison.md) |
 | MCP servers | [MCP guide](../docs/mcp-servers.md) |
-| Prompt patterns | [20 prompt patterns](../docs/prompt-patterns.md) |
+| Prompt patterns | [22 prompt patterns](../docs/prompt-patterns.md) |
 | Full reference | [Power user guide (667 lines)](../docs/guide.md) |
 | Agent Teams | [Agent Teams guide](../docs/agent-teams.md) |
 | CI/CD automation | [GitHub Actions guide](../docs/github-actions.md) |

--- a/skills/doc-finalise/SKILL.md
+++ b/skills/doc-finalise/SKILL.md
@@ -1,0 +1,108 @@
+---
+name: doc-finalise
+description: >
+  Finalise a Word (.docx) deliverable with embedded visuals, integrity checks,
+  and a paste-ready commit block. Covers status reports, board packs, sprint
+  retrospectives, RFCs, and compliance documents where factual accuracy and
+  style consistency both matter.
+  Triggers: "finalise this doc", "doc-finalise", "wrap the report", "embed the chart", "board pack".
+
+  Do NOT use this skill for: drafting from scratch (use a writer skill), slide decks (.pptx),
+  or plain markdown where style inheritance and PDF rendering are not concerns.
+metadata:
+  user-invocable: true
+  slash-command: /doc-finalise
+  proactive: false
+title: "Document Finalisation"
+parent: Skills & Extensibility
+---
+# Document Finalisation
+
+Structured workflow for finishing a `.docx` deliverable: programmatic integrity check, embedded visuals, style normalisation, PDF regeneration, and a Closeout Trio summary. Built for the case where a reviewer will spot every wandering em-dash and every rounding drift.
+
+## When to Use
+
+- Executive status reports where rounded numbers must be replaced with exact ones.
+- Board packs and compliance documents with claim-level provenance requirements.
+- Any second-pass edit where "tighten this up" has historically rephrased a number into an inaccuracy.
+- Documents where visuals must survive the `.docx` → PDF conversion unchanged.
+
+## When Not to Use
+
+- Drafting the document from scratch — use a writer skill, then finalise with this one.
+- Slide decks (`.pptx`) — different library, different gotchas.
+- Plain markdown deliverables — style inheritance and PDF rendering are not in scope.
+
+## Steps
+
+1. **Read the docx toolchain reference before touching the file.** Load the Anthropic bundled docx skill (if available) or your project's `python-docx` reference. Do not skip this even if the model thinks it knows the API — the style-map and image-anchor details are where real documents break.
+
+2. **Inventory the source document programmatically.** Capture a baseline so any later claim of "I only changed X" is verifiable.
+
+   | Check | What to capture |
+   |---|---|
+   | Structure | Paragraph count, table count, section count, page count |
+   | Styles | Full style map, every explicit style override on every run |
+   | Typography | Em-dash (`—`) and en-dash (`–`) counts across `document.xml`, `header*.xml`, `footer*.xml` |
+   | Assets | Every embedded image (id, size, anchor paragraph text) |
+   | Theme | Font references — `majorFont` / `minorFont` — and any theme fallback |
+
+3. **Embed visuals as PNG, not linked images.** Linked images break on email handoff and PDF conversion.
+   - Use `doc.add_picture()` inside a centred paragraph, not floating anchors.
+   - Insert at **named text anchors** — "before the paragraph starting with `Quarterly summary`" — not "around the end of section 3". Paragraph indices shift; sentence fragments do not.
+   - Render charts with `matplotlib` at the target font size, save to PNG at 150 DPI minimum, embed from memory.
+
+4. **Normalise style inheritance once.** Set explicit values so run-level overrides become non-conflicting rather than competing.
+   - Explicit font name on `Normal` and every heading style.
+   - Explicit line spacing on `docDefaults`.
+   - Replace theme font references (`majorFont` / `minorFont`) with concrete names so the doc renders the same on a machine without the source theme installed.
+
+5. **Regenerate the PDF and spot-check it, not the docx.** Visuals and fonts can render correctly in Word and badly in the PDF conversion.
+   - `libreoffice --headless --convert-to pdf <file>.docx`
+   - Rasterise the pages with embedded visuals (`pdftoppm` or `pdf2image`).
+   - Compare each visual in the PDF against the original PNG. Size, crop, DPI loss, font substitution — all show up here, not in the docx.
+
+6. **Produce a Closeout Trio summary.** See [prompt-patterns.md §22](../../docs/prompt-patterns.md#22-the-closeout-trio). Include concrete numbers, not prose.
+
+   ```
+   What I did
+   - 98 paragraphs → 108 paragraphs (+10: two five-element chart blocks)
+   - 3 embedded PNGs, 150 DPI, 412/438/391 KB
+   - PDF regenerated, 14 pages, visuals verified against source PNGs
+   - Em-dash count unchanged across body, headers, footers (47)
+
+   What I could not do and why
+   - No repo access — producing files + paste-ready commit block instead
+
+   What needs your eyes
+   - Appendix B table row 4 conflicts with prose on page 7 (see anti-pattern 22 — flagged, not resolved)
+   - Cover-page colour matches brand guide sample but sandbox has no Calibri installed (see Gotchas)
+   ```
+
+7. **If sandboxed without repo access, emit a paste-ready commit block.** Do not fabricate a commit or a push.
+
+   ```
+   # Paste-ready commit
+   Branch: docs/q3-board-pack
+   Message: finalise(q3): embed charts, normalise styles, regen PDF
+   Files:
+     - reports/q3-board-pack.docx
+     - reports/q3-board-pack.pdf
+     - reports/assets/chart-revenue.png
+     - reports/assets/chart-runrate.png
+   ```
+
+## Gotchas
+
+- **Default stack:** `python-docx` + `matplotlib` for anything chart-heavy. The unpack-and-rewrite-XML route is a last resort — it breaks style inheritance and is easy to get subtly wrong. Stick with the library APIs.
+- **Font fallback:** sandboxes without Calibri fall back to Liberation Sans. Visually near-identical at chart scale, but different metrics. Do not claim a chart was "rendered in Calibri" unless you verified the font is installed.
+- **Accessibility:** `libreoffice --headless --convert-to pdf` emits **tagged PDFs by default**. Relevant when the audience is accessibility-sensitive (screen readers, WCAG). Do not strip tags during any post-processing step.
+- **Em-dash and en-dash audit:** these characters travel poorly through copy-paste and some linters auto-"fix" them. A pre/post count across `document.xml`, headers, and footers catches silent drift.
+- **Silent conflict resolution:** if two numbers in the same document disagree, flag the conflict — do not pick one. See [anti-patterns.md §22](../../docs/anti-patterns.md).
+
+## Related
+
+- [prompt-patterns.md §21 — SOURCE FACTS / CHANGE LIST](../../docs/prompt-patterns.md) — use this pattern to structure the rewrite instruction before invoking the skill.
+- [prompt-patterns.md §22 — The Closeout Trio](../../docs/prompt-patterns.md) — the summary format step 6 produces.
+- [skills/verification-before-completion/](../verification-before-completion/) — the code-side equivalent of the Closeout Trio.
+- [skills/handoff/](../handoff/) — session-end summary (different scope: session, not deliverable).


### PR DESCRIPTION
## Summary
- New plays: `docs/harness-pattern.md` (Owen Hawkins / CDL) and `docs/steering-files.md` (enforceable house rules)
- New skill: `skills/doc-finalise/` — `.docx` finalisation with embedded visuals, style normalisation, PDF regen, Closeout Trio summary
- Prompt patterns §21 (SOURCE FACTS / CHANGE LIST) and §22 (The Closeout Trio); anti-pattern §22 (Silent Conflict Resolution)
- `awesome-claude-code`: Tribune companion CLI
- README + onboarding count refresh: 29 skills, 22 prompt patterns, 22 anti-patterns

## Test plan
- [ ] Pages site rebuilds and new docs render under `/docs/harness-pattern/` and `/docs/steering-files/`
- [ ] Skill index lists `doc-finalise`
- [ ] No broken cross-links to `prompt-patterns.md` §21/§22 or `anti-patterns.md` §22

🤖 Generated with [Claude Code](https://claude.com/claude-code)