### PR TITLE
Add retry skill + claude-retry.sh outage-resilience wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -467,6 +467,7 @@ Every skill is a drop-in `/command` that teaches Claude a specific workflow. Cop
 | **[security-check](skills/security-check/)** | Quick security scan for OWASP Top 10: secrets, injection, XSS, auth issues | Before releases or after security-sensitive changes |
 | **[verification-before-completion](skills/verification-before-completion/)** | Forces Claude to prove work is done with actual test/build output | Automatically before "done" claims |
 | **[session-doubt](skills/session-doubt/)** | Two-question reflective close-out: enumerate + root-cause what it's least confident about, then name the biggest blind spot | After substantive work, alongside verification |
+| **[retry](skills/retry/)** | Survive Claude API errors/outages: a `claude-retry.sh` wrapper that relaunches with backoff on transient 5xx/overload/rate-limit, plus a `/retry` skill to cleanly resume the cut-off task afterward | When the API is overloaded, rate-limited, or down |
 
 </details>
 

--- a/scripts/claude-retry.sh
+++ b/scripts/claude-retry.sh
@@ -1,0 +1,119 @@
+#!/usr/bin/env bash
+# claude-retry.sh — run the `claude` CLI and auto-relaunch it with exponential
+# backoff when it dies from a TRANSIENT failure (API overload/529, 500/503,
+# rate limit, network blip, Claude outage). Permanent failures (bad auth,
+# no credit) are NOT retried — relaunching just burns the same error.
+#
+# Works where a model-invoked /retry skill can't: when Claude itself is down,
+# the model isn't running to help, so this lives at the shell level.
+#
+# Usage:
+#   claude-retry [any args you'd pass to `claude`]
+#   claude-retry -p "summarize this repo"          # headless: scans output
+#   claude-retry                                    # interactive TUI: retries on crash
+#
+# On a retry the conversation is resumed with `--continue` (unless you already
+# passed --continue/-c/--resume), so you pick up where it died.
+#
+# Env knobs:
+#   CLAUDE_RETRY_MAX     max retries after the first attempt   (default 5)
+#   CLAUDE_RETRY_BASE    base backoff seconds, doubles each try (default 4)
+#   CLAUDE_RETRY_CAP     max backoff seconds per wait           (default 120)
+#   CLAUDE_BIN           path to the claude binary              (default: claude on PATH)
+set -uo pipefail
+
+MAX="${CLAUDE_RETRY_MAX:-5}"
+BASE="${CLAUDE_RETRY_BASE:-4}"
+CAP="${CLAUDE_RETRY_CAP:-120}"
+BIN="${CLAUDE_BIN:-claude}"
+LOG="$HOME/.claude/claude-retry.log"
+
+command -v "$BIN" >/dev/null 2>&1 || { echo "claude-retry: '$BIN' not found on PATH" >&2; exit 127; }
+
+# Transient = worth retrying. Matched case-insensitively against captured output.
+TRANSIENT='overloaded|529|internal server error|500|503|service unavailable|rate.?limit|rate_limit|too many requests|timeout|timed out|econnreset|etimedout|enotfound|fetch failed|socket hang up|connection (reset|refused|error)|upstream|bad gateway|502|temporarily'
+# Permanent = never retry, even on non-zero exit.
+PERMANENT='invalid api key|invalid x-api-key|authentication_error|401|403|please run /login|credit balance|insufficient|quota|billing|permission denied'
+
+# Is this an interactive TUI run? (no -p/--print, and stdout is a terminal)
+interactive=1
+for a in "$@"; do
+  case "$a" in -p|--print) interactive=0 ;; esac
+done
+[ -t 1 ] || interactive=0
+
+# Does the user already specify a resume flag? If so, don't add --continue.
+has_resume=0
+for a in "$@"; do
+  case "$a" in -c|--continue|--resume|-r) has_resume=1 ;; esac
+done
+
+log() { printf '%s %s\n' "$(date '+%Y-%m-%dT%H:%M:%S')" "$1" >>"$LOG"; }
+
+attempt=0
+while :; do
+  # On a retry, add --continue so the conversation resumes (unless user set their own).
+  extra=()
+  if [ "$attempt" -gt 0 ] && [ "$has_resume" -eq 0 ]; then
+    extra+=(--continue)
+  fi
+
+  # Safe empty-array expansion (macOS bash 3.2 + set -u).
+  args=("${extra[@]+"${extra[@]}"}" "$@")
+
+  if [ "$interactive" -eq 1 ]; then
+    # TUI: run attached. Can't scan a live TUI, so classify on exit code only.
+    "$BIN" "${args[@]}"
+    code=$?
+    captured=""
+  else
+    # Headless: capture combined output, echo it through, then classify on content.
+    tmp="$(mktemp -t claude-retry.XXXXXX)"
+    "$BIN" "${args[@]}" 2>&1 | tee "$tmp"
+    code=${PIPESTATUS[0]}
+    captured="$(cat "$tmp")"
+    rm -f "$tmp"
+  fi
+
+  # Success.
+  if [ "$code" -eq 0 ]; then
+    [ "$attempt" -gt 0 ] && log "recovered after $attempt retr(y/ies)"
+    exit 0
+  fi
+
+  # User aborted (Ctrl-C = 130, SIGTERM = 143). Don't fight the user.
+  if [ "$code" -eq 130 ] || [ "$code" -eq 143 ]; then
+    exit "$code"
+  fi
+
+  low="$(printf '%s' "$captured" | tr '[:upper:]' '[:lower:]')"
+
+  # Permanent error in output → stop now.
+  if [ -n "$low" ] && printf '%s' "$low" | grep -Eq "$PERMANENT"; then
+    echo "claude-retry: permanent error (auth/credit) — not retrying." >&2
+    log "permanent error, giving up (exit $code)"
+    exit "$code"
+  fi
+
+  # Headless with output that has NO transient marker → treat as a real failure
+  # (e.g. your prompt/tool genuinely failed), not an outage. Don't loop on it.
+  if [ "$interactive" -eq 0 ] && [ -n "$low" ] && ! printf '%s' "$low" | grep -Eq "$TRANSIENT"; then
+    echo "claude-retry: non-transient failure (exit $code) — not retrying." >&2
+    log "non-transient failure, giving up (exit $code)"
+    exit "$code"
+  fi
+
+  attempt=$((attempt + 1))
+  if [ "$attempt" -gt "$MAX" ]; then
+    echo "claude-retry: still failing after $MAX retries — giving up." >&2
+    log "exhausted $MAX retries (exit $code)"
+    exit "$code"
+  fi
+
+  # Exponential backoff, capped.
+  wait=$((BASE * (1 << (attempt - 1))))
+  [ "$wait" -gt "$CAP" ] && wait="$CAP"
+  echo "claude-retry: transient failure (exit $code). Retry $attempt/$MAX in ${wait}s…" >&2
+  log "transient failure (exit $code), retry $attempt/$MAX in ${wait}s"
+  sleep "$wait"
+done

--- a/skills/retry/SKILL.md
+++ b/skills/retry/SKILL.md
@@ -1,0 +1,63 @@
+---
+name: retry
+description: Resume and re-run the last task that failed because of a Claude API error or outage (overloaded/529, 500/503, rate limit, network drop, "Claude is down"). Use AFTER the error clears, when the user says "/retry", "retry", "try that again", "it errored, redo it", "pick up where you crashed", or "the API was down, continue". For surviving a live outage unattended, point them at the claude-retry wrapper script instead. Do NOT use to retry a task that failed on its own merits (bad logic, failing test) — that's a fix, not a retry.
+---
+
+# Retry After an API Error / Outage
+
+A transient Anthropic API failure (overload, 5xx, rate limit, network blip, or a
+full outage) aborts the turn mid-task. This skill cleanly resumes the work that
+got cut off — it does NOT start fresh and does NOT re-litigate decisions already
+made before the error.
+
+## First: is this actually a retry?
+
+Only proceed if the last failure was **infrastructure**, not the work itself:
+
+- ✅ Retry: `Overloaded`, `429`/`529`, `500`/`503`, `rate_limit`, `fetch failed`,
+  `socket hang up`, "Claude is down", the turn just stopped with no result.
+- ❌ Not a retry — that's a fix: a test failed, a build broke, wrong output, a
+  logic bug. Don't blindly redo it; diagnose. Say so and switch to fixing.
+
+If it's ambiguous, ask the user which it was before acting.
+
+## Procedure
+
+1. **Reconstruct where it died.** Read the last few turns + any handoff/state
+   (`.omc/state/`, `.omc/handoffs/`, todos, open files) to find the exact action
+   that was in flight when the error hit. Don't assume — verify against the
+   actual repo/file state, since a partial write may have landed.
+
+2. **Check for partial work.** `git status --short` and inspect the target
+   file(s). The failed action may have half-completed (a file written but not
+   verified, a commit started). Reconcile before redoing, so you don't double-apply.
+
+3. **Re-run only the cut-off action**, not the whole task. Pick up from the last
+   verified-complete step. If several steps remain, restate the short remaining
+   list first so the user can confirm scope.
+
+4. **Verify end-to-end** before claiming done (build/test as the project
+   requires) — the interruption means nothing downstream was checked.
+
+## Surviving a LIVE outage (the wrapper)
+
+This skill can't help while the API is actually down — the model isn't running to
+invoke it. For that, use the shell wrapper, which relaunches the CLI with
+exponential backoff and resumes via `--continue`:
+
+```bash
+~/.claude/scripts/claude-retry.sh [any normal claude args]
+# e.g.  ~/.claude/scripts/claude-retry.sh -p "finish the migration"
+#       ~/.claude/scripts/claude-retry.sh           # interactive TUI
+```
+
+It retries only transient failures (overload/5xx/rate-limit/network), backs off
+4s→8s→16s… (capped), and stops immediately on auth/credit errors. Suggest a
+shell alias for convenience:
+
+```bash
+alias claude-r='~/.claude/scripts/claude-retry.sh'
+```
+
+Tune via env: `CLAUDE_RETRY_MAX` (default 5), `CLAUDE_RETRY_BASE` (4s),
+`CLAUDE_RETRY_CAP` (120s). Log at `~/.claude/claude-retry.log`.


### PR DESCRIPTION
Adds outage/API-error resilience for Claude Code.

## What
- **`scripts/claude-retry.sh`** — wraps the `claude` CLI, relaunches with exponential backoff (4s→8s→16s…, capped) on **transient** failures: overload/529, 500/503, rate limit, network drops. Resumes via `--continue`. Stops immediately on auth/credit errors and on genuine non-transient headless failures. Works where a model-invoked skill can't — during a live outage.
- **`skills/retry/SKILL.md`** — `/retry` skill to cleanly resume the cut-off task *after* an error clears: reconstructs where the turn died, checks for half-finished writes, re-runs only the remaining step, verifies. Guards against retrying merit failures (a failing test is a fix, not a retry).
- README indexed under **Environment & Safety**.

## Tested
Smoke-tested the wrapper's three branches: transient→recovers, permanent(auth)→stops, non-transient→stops. Bash 3.2 (macOS) compatible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)