### PR TITLE
README visual upgrade: branded hero + unified diagram design system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,18 +1,17 @@
 <div align="center">
 
-# The Claude Code Playbook
+<picture>
+  <source media="(prefers-color-scheme: dark)" srcset="assets/images/readme/hero-dark.svg">
+  <img src="assets/images/readme/hero-light.svg" alt="The Claude Code Playbook — Stop prompting. Start engineering." width="100%">
+</picture>
 
-### Stop prompting. Start engineering.
-
-<sub>Built by <strong>Force Information Systems</strong> · A <strong>Harris Computer</strong> Company · Part of <strong>Constellation Software</strong></sub>
-
-[![Quick Start](https://img.shields.io/badge/Quick_Start-0078D4?style=for-the-badge&logo=rocket&logoColor=white)](#quick-start)
-[![Docs Site](https://img.shields.io/badge/Docs_Site-00B4D8?style=for-the-badge&logo=book&logoColor=white)](https://ao92265.github.io/claude-code-playbook/)
-[![Skills](https://img.shields.io/badge/Skills-52_included-8B5CF6?style=for-the-badge&logo=puzzle-piece&logoColor=white)](#skills-reference)
-[![Hooks](https://img.shields.io/badge/Hooks-28_included-EF4444?style=for-the-badge&logoColor=white)](#hooks)
+[![Quick Start](https://img.shields.io/badge/Quick_Start-5E6AD2?style=for-the-badge&logo=rocket&logoColor=white)](#quick-start)
+[![Docs Site](https://img.shields.io/badge/Docs_Site-00B8CC?style=for-the-badge&logo=book&logoColor=white)](https://ao92265.github.io/claude-code-playbook/)
+[![Skills](https://img.shields.io/badge/Skills-52_included-5E6AD2?style=for-the-badge&logo=puzzle-piece&logoColor=white)](#skills-reference)
+[![Hooks](https://img.shields.io/badge/Hooks-28_included-EB5757?style=for-the-badge&logoColor=white)](#hooks)
 [![CI](https://img.shields.io/github/actions/workflow/status/ao92265/claude-code-playbook/validate.yml?style=for-the-badge&label=CI&logo=github)](https://github.com/ao92265/claude-code-playbook/actions/workflows/validate.yml)
-[![License](https://img.shields.io/badge/License-MIT-22C55E?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
-[![Stars](https://img.shields.io/github/stars/ao92265/claude-code-playbook?style=for-the-badge&logo=github&color=EAB308)](https://github.com/ao92265/claude-code-playbook/stargazers)
+[![License](https://img.shields.io/badge/License-MIT-27A644?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
+[![Stars](https://img.shields.io/github/stars/ao92265/claude-code-playbook?style=for-the-badge&logo=github&color=F0BF00)](https://github.com/ao92265/claude-code-playbook/stargazers)
 
 <br/>
 
@@ -21,12 +20,12 @@
 
 <br/>
 
-<img src="https://img.shields.io/badge/52-Skills-8B5CF6?style=flat-square" alt="52 Skills"/>
-<img src="https://img.shields.io/badge/12-Templates-F97316?style=flat-square" alt="12 Templates"/>
-<img src="https://img.shields.io/badge/28-Hooks-EF4444?style=flat-square" alt="28 Hooks"/>
-<img src="https://img.shields.io/badge/67-Docs-0078D4?style=flat-square" alt="67 Docs"/>
-<img src="https://img.shields.io/badge/5-Examples-22C55E?style=flat-square" alt="5 Examples"/>
-<img src="https://img.shields.io/badge/24-Anti--Patterns-EC4899?style=flat-square" alt="24 Anti-Patterns"/>
+<img src="https://img.shields.io/badge/52-Skills-5E6AD2?style=flat-square" alt="52 Skills"/>
+<img src="https://img.shields.io/badge/12-Templates-FC7840?style=flat-square" alt="12 Templates"/>
+<img src="https://img.shields.io/badge/28-Hooks-EB5757?style=flat-square" alt="28 Hooks"/>
+<img src="https://img.shields.io/badge/67-Docs-4EA7FC?style=flat-square" alt="67 Docs"/>
+<img src="https://img.shields.io/badge/5-Examples-27A644?style=flat-square" alt="5 Examples"/>
+<img src="https://img.shields.io/badge/24-Anti--Patterns-F0BF00?style=flat-square" alt="24 Anti-Patterns"/>
 
 </div>
 
@@ -38,15 +37,20 @@ Every successful Claude Code session follows the same rhythm. Break this loop an
 
 ```mermaid
 graph LR
-    A["Request"] --> B["Implement"]
-    B --> C["Verify"]
-    C --> D["Close"]
-    D -->|"New task"| A
+    A(["Request"]) --> B["Implement"]
+    B --> C{"Verify"}
+    C -->|"pass"| D(["Close"])
+    C -.->|"fail"| B
+    D -->|"new task"| A
 
-    style A fill:#4A90D9,stroke:#357ABD,color:#fff
-    style B fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style C fill:#50C878,stroke:#3CB371,color:#fff
-    style D fill:#FF6B6B,stroke:#EE5A5A,color:#fff
+    classDef info fill:#4EA7FC,stroke:#2E86D9,color:#0B1220
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    class A info
+    class B primary
+    class C warn
+    class D success
 ```
 
 > **The cardinal rule:** Each step has a clear boundary. Don't blur them. Plan in one session, execute in another. Verify with real tests, not code inspection.
@@ -124,16 +128,18 @@ graph TB
     CC --> DB
     CC --> GH
 
-    style CC fill:#4A90D9,stroke:#357ABD,color:#fff
-    style CM fill:#50C878,stroke:#3CB371,color:#fff
-    style SK fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style HK fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style OMC fill:#FFB347,stroke:#FFA500,color:#333
-    style BMAD fill:#FFB347,stroke:#FFA500,color:#333
-    style C7 fill:#FFB347,stroke:#FFA500,color:#333
-    style BR fill:#DDA0DD,stroke:#BA55D3,color:#333
-    style DB fill:#DDA0DD,stroke:#BA55D3,color:#333
-    style GH fill:#DDA0DD,stroke:#BA55D3,color:#333
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef info fill:#4EA7FC,stroke:#2E86D9,color:#0B1220
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    classDef danger fill:#EB5757,stroke:#C43D3D,color:#FFFFFF
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef dark fill:#232326,stroke:#3E3E44,color:#F7F8F8
+    class CC primary
+    class CM success
+    class SK info
+    class HK danger
+    class OMC,BMAD,C7 warn
+    class BR,DB,GH dark
 ```
 
 <br/>
@@ -270,13 +276,19 @@ graph TB
     BM --> SEC["Security Auditor<br/><em>Vulnerabilities</em>"]
     BM --> PM["Product Manager<br/><em>Scope & impact</em>"]
 
-    style YOU fill:#4A90D9,stroke:#357ABD,color:#fff
-    style BM fill:#FFB347,stroke:#FFA500,color:#333
-    style AR fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style DEV fill:#50C878,stroke:#3CB371,color:#fff
-    style QA fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style SEC fill:#FF69B4,stroke:#DB7093,color:#fff
-    style PM fill:#DDA0DD,stroke:#BA55D3,color:#333
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef info fill:#4EA7FC,stroke:#2E86D9,color:#0B1220
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef danger fill:#EB5757,stroke:#C43D3D,color:#FFFFFF
+    classDef dark fill:#232326,stroke:#3E3E44,color:#F7F8F8
+    class YOU info
+    class BM warn
+    class AR primary
+    class DEV success
+    class QA warn
+    class SEC danger
+    class PM dark
 ```
 
 **Best for:** Architecture reviews, code reviews, sprint planning, production incident analysis.
@@ -310,13 +322,18 @@ graph LR
     RL --> S
     RL --> O
 
-    style AP fill:#4A90D9,stroke:#357ABD,color:#fff
-    style UW fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style RL fill:#50C878,stroke:#3CB371,color:#fff
-    style TD fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style H fill:#90EE90,stroke:#32CD32,color:#333
-    style S fill:#FFB347,stroke:#FFA500,color:#333
-    style O fill:#FF69B4,stroke:#DB7093,color:#fff
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef info fill:#4EA7FC,stroke:#2E86D9,color:#0B1220
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef dark fill:#232326,stroke:#3E3E44,color:#F7F8F8
+    class AP primary
+    class UW info
+    class RL success
+    class TD warn
+    class H dark
+    class S info
+    class O primary
 ```
 
 **Best for:** Autonomous feature dev, parallel codebase changes, persistent bug fixing. Saves 30-50% on tokens.
@@ -484,12 +501,18 @@ graph LR
 
     F["/clear"] --> A
 
-    style A fill:#50C878,stroke:#3CB371,color:#fff
-    style B fill:#90EE90,stroke:#32CD32,color:#333
-    style C fill:#FFB347,stroke:#FFA500,color:#333
-    style D fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style E fill:#DC143C,stroke:#B22222,color:#fff
-    style F fill:#4A90D9,stroke:#357ABD,color:#fff
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    classDef teal fill:#00B8CC,stroke:#00919F,color:#04252A
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef orange fill:#FC7840,stroke:#D9581F,color:#2A1204
+    classDef danger fill:#EB5757,stroke:#C43D3D,color:#FFFFFF
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    class A success
+    class B teal
+    class C warn
+    class D orange
+    class E danger
+    class F primary
 ```
 
 When Claude gives generic answers, your context is polluted. `/clear` when switching tasks. `/compact` at 50%. Fresh session above 80%.
@@ -511,12 +534,10 @@ graph LR
 
     P3 -->|"New session"| E1
 
-    style P1 fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style P2 fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style P3 fill:#7B68EE,stroke:#6A5ACD,color:#fff
-    style E1 fill:#50C878,stroke:#3CB371,color:#fff
-    style E2 fill:#50C878,stroke:#3CB371,color:#fff
-    style E3 fill:#50C878,stroke:#3CB371,color:#fff
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    class P1,P2,P3 primary
+    class E1,E2,E3 success
 ```
 
 Planning context pollutes implementation focus. Three rejected approaches in memory = defensive, over-engineered code.
@@ -537,10 +558,10 @@ graph TB
     P --> W2["Worker 2<br/><em>Own worktree</em>"]
     P --> W3["Worker 3<br/><em>Own worktree</em>"]
 
-    style P fill:#4A90D9,stroke:#357ABD,color:#fff
-    style W1 fill:#50C878,stroke:#3CB371,color:#fff
-    style W2 fill:#50C878,stroke:#3CB371,color:#fff
-    style W3 fill:#50C878,stroke:#3CB371,color:#fff
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    class P primary
+    class W1,W2,W3 success
 ```
 
 - Cap at 3-4 parallel agents
@@ -613,6 +634,7 @@ Never append to shared context files. Always replace the entire content and keep
 Hooks are deterministic guard rails — they fire on tool events whether or not the model remembers to check.
 
 ```mermaid
+%%{init: {"themeVariables": {"actorBkg": "#5E6AD2", "actorTextColor": "#FFFFFF", "actorBorder": "#4653B8", "activationBkgColor": "#F0BF00"}}}%%
 sequenceDiagram
     participant You
     participant Claude
@@ -665,12 +687,10 @@ graph LR
     B2 -.->|"99% faster"| A2
     B3 -.->|"50x more"| A3
 
-    style B1 fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style B2 fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style B3 fill:#FF6B6B,stroke:#EE5A5A,color:#fff
-    style A1 fill:#50C878,stroke:#3CB371,color:#fff
-    style A2 fill:#50C878,stroke:#3CB371,color:#fff
-    style A3 fill:#50C878,stroke:#3CB371,color:#fff
+    classDef danger fill:#EB5757,stroke:#C43D3D,color:#FFFFFF
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    class B1,B2,B3 danger
+    class A1,A2,A3 success
 ```
 
 | Metric | Before | After |

--- a/assets/images/readme/hero-dark.svg
+++ b/assets/images/readme/hero-dark.svg
@@ -1,0 +1,59 @@
+<svg width="1200" height="340" viewBox="0 0 1200 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Claude Code Playbook — Stop prompting. Start engineering.">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="0%" r="90%">
+      <stop offset="0%" stop-color="#5E6AD2" stop-opacity="0.28"/>
+      <stop offset="45%" stop-color="#5E6AD2" stop-opacity="0.10"/>
+      <stop offset="100%" stop-color="#5E6AD2" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#5E6AD2" stop-opacity="0"/>
+      <stop offset="18%" stop-color="#5E6AD2"/>
+      <stop offset="50%" stop-color="#00B8CC"/>
+      <stop offset="82%" stop-color="#5E6AD2"/>
+      <stop offset="100%" stop-color="#5E6AD2" stop-opacity="0"/>
+    </linearGradient>
+    <linearGradient id="titlegrad" x1="0" y1="0" x2="0" y2="1">
+      <stop offset="0%" stop-color="#FFFFFF"/>
+      <stop offset="100%" stop-color="#C9CEDA"/>
+    </linearGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1.2" fill="#F7F8F8" fill-opacity="0.045"/>
+    </pattern>
+    <clipPath id="panelclip"><rect x="1" y="1" width="1198" height="338" rx="18"/></clipPath>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="338" rx="18" fill="#08090A"/>
+  <g clip-path="url(#panelclip)">
+    <rect x="1" y="1" width="1198" height="338" fill="url(#dots)"/>
+    <rect x="1" y="1" width="1198" height="338" fill="url(#glow)"/>
+    <!-- terminal chrome motif, top-left -->
+    <g transform="translate(36,30)">
+      <rect width="150" height="94" rx="10" fill="#141516" stroke="#23252A"/>
+      <circle cx="16" cy="15" r="4" fill="#EB5757"/>
+      <circle cx="30" cy="15" r="4" fill="#F0BF00"/>
+      <circle cx="44" cy="15" r="4" fill="#27A644"/>
+      <text x="14" y="46" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#8A8F98">$ claude</text>
+      <text x="14" y="66" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#5E6AD2">&gt; /check-env</text>
+      <text x="14" y="84" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#27A644">✓ verified</text>
+    </g>
+    <!-- loop motif, top-right -->
+    <g transform="translate(1010,36)" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="11">
+      <rect x="0" y="0" width="118" height="26" rx="13" fill="#141516" stroke="#23252A"/>
+      <text x="59" y="17" text-anchor="middle" fill="#4EA7FC">request</text>
+      <rect x="0" y="34" width="118" height="26" rx="13" fill="#141516" stroke="#23252A"/>
+      <text x="59" y="51" text-anchor="middle" fill="#5E6AD2">implement</text>
+      <rect x="0" y="68" width="118" height="26" rx="13" fill="#141516" stroke="#23252A"/>
+      <text x="59" y="85" text-anchor="middle" fill="#27A644">verify</text>
+      <rect x="0" y="102" width="118" height="26" rx="13" fill="#141516" stroke="#23252A"/>
+      <text x="59" y="119" text-anchor="middle" fill="#FC7840">close</text>
+    </g>
+  </g>
+
+  <text x="600" y="150" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="52" font-weight="700" letter-spacing="-1.5" fill="url(#titlegrad)">The Claude Code Playbook</text>
+  <text x="600" y="196" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="21" font-weight="500" fill="#8A8F98">Stop prompting. <tspan fill="#D0D6E0">Start engineering.</tspan></text>
+
+  <rect x="300" y="228" width="600" height="2" rx="1" fill="url(#rule)"/>
+
+  <text x="600" y="266" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12.5" font-weight="600" letter-spacing="2.4" fill="#62666D">SKILLS · HOOKS · TEMPLATES · MULTI-AGENT ORCHESTRATION · HARD-WON LESSONS</text>
+  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#62666D">Force Information Systems · A Harris Computer Company · Part of Constellation Software</text>
+</svg>

--- a/assets/images/readme/hero-light.svg
+++ b/assets/images/readme/hero-light.svg
@@ -1,0 +1,53 @@
+<svg width="1200" height="340" viewBox="0 0 1200 340" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="The Claude Code Playbook — Stop prompting. Start engineering.">
+  <defs>
+    <radialGradient id="glow" cx="50%" cy="0%" r="90%">
+      <stop offset="0%" stop-color="#5E6AD2" stop-opacity="0.14"/>
+      <stop offset="45%" stop-color="#5E6AD2" stop-opacity="0.05"/>
+      <stop offset="100%" stop-color="#5E6AD2" stop-opacity="0"/>
+    </radialGradient>
+    <linearGradient id="rule" x1="0" y1="0" x2="1" y2="0">
+      <stop offset="0%" stop-color="#5E6AD2" stop-opacity="0"/>
+      <stop offset="18%" stop-color="#5E6AD2"/>
+      <stop offset="50%" stop-color="#00B8CC"/>
+      <stop offset="82%" stop-color="#5E6AD2"/>
+      <stop offset="100%" stop-color="#5E6AD2" stop-opacity="0"/>
+    </linearGradient>
+    <pattern id="dots" width="26" height="26" patternUnits="userSpaceOnUse">
+      <circle cx="1.5" cy="1.5" r="1.2" fill="#1a2b4a" fill-opacity="0.05"/>
+    </pattern>
+    <clipPath id="panelclip"><rect x="1" y="1" width="1198" height="338" rx="18"/></clipPath>
+  </defs>
+
+  <rect x="1" y="1" width="1198" height="338" rx="18" fill="#FBFBFC" stroke="#E4E6EA"/>
+  <g clip-path="url(#panelclip)">
+    <rect x="1" y="1" width="1198" height="338" fill="url(#dots)"/>
+    <rect x="1" y="1" width="1198" height="338" fill="url(#glow)"/>
+    <g transform="translate(36,30)">
+      <rect width="150" height="94" rx="10" fill="#FFFFFF" stroke="#E4E6EA"/>
+      <circle cx="16" cy="15" r="4" fill="#EB5757"/>
+      <circle cx="30" cy="15" r="4" fill="#F0BF00"/>
+      <circle cx="44" cy="15" r="4" fill="#27A644"/>
+      <text x="14" y="46" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#8A8F98">$ claude</text>
+      <text x="14" y="66" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#5E6AD2">&gt; /check-env</text>
+      <text x="14" y="84" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="12" fill="#1F8737">✓ verified</text>
+    </g>
+    <g transform="translate(1010,36)" font-family="ui-monospace,SFMono-Regular,Menlo,Consolas,monospace" font-size="11">
+      <rect x="0" y="0" width="118" height="26" rx="13" fill="#FFFFFF" stroke="#E4E6EA"/>
+      <text x="59" y="17" text-anchor="middle" fill="#2E86D9">request</text>
+      <rect x="0" y="34" width="118" height="26" rx="13" fill="#FFFFFF" stroke="#E4E6EA"/>
+      <text x="59" y="51" text-anchor="middle" fill="#5E6AD2">implement</text>
+      <rect x="0" y="68" width="118" height="26" rx="13" fill="#FFFFFF" stroke="#E4E6EA"/>
+      <text x="59" y="85" text-anchor="middle" fill="#1F8737">verify</text>
+      <rect x="0" y="102" width="118" height="26" rx="13" fill="#FFFFFF" stroke="#E4E6EA"/>
+      <text x="59" y="119" text-anchor="middle" fill="#E05A1F">close</text>
+    </g>
+  </g>
+
+  <text x="600" y="150" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="52" font-weight="700" letter-spacing="-1.5" fill="#0F1011">The Claude Code Playbook</text>
+  <text x="600" y="196" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="21" font-weight="500" fill="#8A8F98">Stop prompting. <tspan fill="#3D4249">Start engineering.</tspan></text>
+
+  <rect x="300" y="228" width="600" height="2" rx="1" fill="url(#rule)"/>
+
+  <text x="600" y="266" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12.5" font-weight="600" letter-spacing="2.4" fill="#8A8F98">SKILLS · HOOKS · TEMPLATES · MULTI-AGENT ORCHESTRATION · HARD-WON LESSONS</text>
+  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#8A8F98">Force Information Systems · A Harris Computer Company · Part of Constellation Software</text>
+</svg>


### PR DESCRIPTION
Follow-up to #12 — the visual layer.

- **Hero banner** — custom SVG, dark and light variants switched via `<picture prefers-color-scheme>`. Terminal and core-loop motifs, Linear-derived palette (indigo/teal on near-black). Deliberately count-free: all numbers stay in CI-checked markdown badges so the counts-drift gate keeps working.
- **Diagram design system** — all 9 Mermaid diagrams restyled from clashing default pastels to one 6-token classDef palette (indigo primary / blue info / green success / amber warn / red danger / graphite neutral). The core-loop diagram also gains the verify-fail back-edge it was missing.
- **Badges** recolored to the same palette; grep-critical patterns (`Skills-52_`, `Hooks-28`, …) untouched.

Verification: hero SVGs and all 9 diagrams render-checked in headless Chrome (mermaid@10 — GitHub's major version, `RENDERED` with no parse errors); all 7 validate.yml jobs pass locally (0 failures).

🤖 Generated with [Claude Code](https://claude.com/claude-code)