### PR TITLE
myinsights: leaderboard M0+M1 — scorecard module, scores export, seeded mock

### DIFF
--- a/skills/myinsights/.gitignore
+++ b/skills/myinsights/.gitignore
@@ -1,1 +1,3 @@
 __pycache__/
+data/
+scores.json

--- a/skills/myinsights/SKILL.md
+++ b/skills/myinsights/SKILL.md
@@ -50,6 +50,22 @@ The built-in `/insights` samples a subset of sessions and reflects the currently
    Then call the `Artifact` tool on `$OUT/report.html`. Favicon `📊`, title "myinsights — all logins merged".
    The renderer also computes a **deterministic ranked Scorecard** (9 factors scored 0–100 by disclosed formulas over `quant.json` + facet outcomes, graded A+→D, weighted into a composite) and styles the report on the Linear design system — both are automatic, no narrative input needed.
 
+## Leaderboard (dormant — no service exists yet)
+
+An **opt-in** Harris community leaderboard is planned but NOT live. Current state: fully dormant. There is no endpoint, no config, and this skill makes **zero network calls** — with or without the files below.
+
+What exists today (local-only):
+- `scorecard.py` — the 9-factor formulas as a shared module (`variant="report"` = the report's numbers; `variant="export"` = clamped to [0,100] for any future wire use).
+- `export_scores.py [quant.json] [scores.json]` — emits a **strict-allowlist** scores.json (schema/formula versions, corpus counts, 9 `{name,score,kind,w}` factors, composite, grade, skill_version — never evidence text, projects, hours, tokens, or anything else from quant.json) and maintains local snapshots under `data/snapshots/` so personal-best deltas compute offline.
+- `leaderboard-mock.html` — a seeded, self-contained demo board (synthetic handles; most-improved deltas, not absolute grades).
+
+Future submission flow (requires a live service, which is gated on sponsor + HR sign-off):
+1. User explicitly opts in and picks a pseudonymous handle.
+2. Skill runs `export_scores.py` and **shows the exact payload for review before anything is sent** (payload-preview is mandatory — no silent submission, no scheduling).
+3. Only the reviewed scores.json is transmitted. Deletion is self-service.
+
+Rules for any future implementation: no endpoint configured → no network code path executes; the payload allowlist is enforced by `tests/test_payload_and_privacy.py`; the board is a voluntary community game, never a performance instrument.
+
 ## Rules
 - **Read-only.** Never write into `~/.claude/usage-data` or `projects`. No secrets emitted.
 - **Self-contained HTML** — inline CSS + SVG only (Artifact CSP blocks CDNs/fonts/remote images). Charts are hand-rolled SVG/CSS bars; body-only (no `<html>/<head>/<body>`).

--- a/skills/myinsights/export_scores.py
+++ b/skills/myinsights/export_scores.py
@@ -1,0 +1,91 @@
+#!/usr/bin/env python3
+"""export_scores.py [quant.json] [out.json]
+Export the myinsights scorecard as a machine-readable scores.json — the ONLY artifact
+that may ever leave the machine (leaderboard wire format).
+
+STRICT ALLOWLIST — the payload contains exactly:
+  schema_version, formula_version, corpus{n_sessions, n_facets, active_days, as_of},
+  factors[{name, score, kind, w}], composite, grade, skill_version
+Nothing else. No evidence strings, no levers, no project areas, no by-hour/by-day data,
+no tokens, no paths. Uses the clamped "export" formula variant (all scores in [0,100]).
+
+Also maintains local snapshots under <skill>/data/snapshots/ so personal-best deltas
+are computable offline: first run writes a baseline; later runs print the delta vs the
+previous snapshot, then append a new one (one per day, same-day overwrites).
+
+No network. Read-only over quant.json; writes only out.json + the snapshot dir.
+"""
+import json, os, sys, glob, subprocess, datetime
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, HERE)
+from scorecard import compute_scores, grade_of, SCHEMA_VERSION, FORMULA_VERSION_EXPORT
+
+SKILL_VERSION = "2026.07.02"
+SNAP_DIR = os.path.join(HERE, "data", "snapshots")
+
+def load_quant(path):
+    if path and os.path.exists(path):
+        return json.load(open(path))
+    default = "/tmp/myinsights/quant.json"
+    if os.path.exists(default):
+        return json.load(open(default))
+    # no quant available — build one (read-only scan, same as the skill's step 1)
+    os.makedirs("/tmp/myinsights", exist_ok=True)
+    subprocess.run([sys.executable, os.path.join(HERE, "gather_all.py"), "/tmp/myinsights"],
+                   check=True, stdout=subprocess.DEVNULL)
+    return json.load(open(default))
+
+def build_payload(q):
+    factors, composite = compute_scores(q, variant="export")
+    return {
+        "schema_version": SCHEMA_VERSION,
+        "formula_version": FORMULA_VERSION_EXPORT,
+        "corpus": {
+            "n_sessions": q.get("sessions", 0),
+            "n_facets": q.get("facet_n", q.get("facet_count", 0)),
+            "active_days": q.get("active_days", 0),
+            "as_of": datetime.date.today().isoformat(),
+        },
+        "factors": [{"name": f["name"], "score": round(f["score"], 1),
+                     "kind": f["kind"], "w": f["w"]} for f in factors],
+        "composite": round(composite, 1),
+        "grade": grade_of(composite),
+        "skill_version": SKILL_VERSION,
+    }
+
+def latest_snapshot():
+    snaps = sorted(glob.glob(os.path.join(SNAP_DIR, "scores-*.json")))
+    return json.load(open(snaps[-1])) if snaps else None
+
+def print_delta(prev, cur):
+    d = cur["composite"] - prev["composite"]
+    print(f"Δ composite vs {prev['corpus']['as_of']}: {d:+.1f}  "
+          f"({prev['composite']} → {cur['composite']}, grade {prev['grade']} → {cur['grade']})")
+    prev_f = {f["name"]: f["score"] for f in prev["factors"]}
+    moved = sorted(((f["name"], f["score"] - prev_f.get(f["name"], f["score"]))
+                    for f in cur["factors"]), key=lambda x: -abs(x[1]))
+    for name, df in moved[:3]:
+        if abs(df) >= 0.05:
+            print(f"  {name}: {df:+.1f}")
+
+def main():
+    quant_path = sys.argv[1] if len(sys.argv) > 1 else None
+    out_path = sys.argv[2] if len(sys.argv) > 2 else "scores.json"
+    q = load_quant(quant_path)
+    payload = build_payload(q)
+
+    prev = latest_snapshot()
+    if prev:
+        print_delta(prev, payload)
+    else:
+        print("baseline snapshot — deltas start from the next run")
+
+    json.dump(payload, open(out_path, "w"), indent=2)
+    os.makedirs(SNAP_DIR, exist_ok=True)
+    snap = os.path.join(SNAP_DIR, f"scores-{payload['corpus']['as_of']}.json")
+    json.dump(payload, open(snap, "w"), indent=2)
+    print(f"wrote {out_path} (composite {payload['composite']} {payload['grade']}) · snapshot {os.path.basename(snap)}")
+
+if __name__ == "__main__":
+    main()

--- a/skills/myinsights/leaderboard-mock.html
+++ b/skills/myinsights/leaderboard-mock.html
@@ -1,0 +1,77 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<title>Harris Claude Code Leaderboard — seeded mock</title>
+<style>
+/* Linear design tokens (design-md/linear). Fully self-contained: no webfonts, no CDN, zero external requests. */
+:root{--bg:#08090A;--panel:#0F1011;--elev:#1C1C1F;--ink:#F7F8F8;--body:#D0D6E0;--muted:#8A8F98;--faint:#62666D;--line:#23252A;--line2:#34343A;--indigo:#5E6AD2;--link:#7070FF;--hover:#828FFF;--blue:#4EA7FC;--teal:#00B8CC;--green:#27A644;--yellow:#F0BF00;--red:#EB5757}
+*{box-sizing:border-box}
+body{margin:0;background:var(--bg);color:var(--ink);font-family:"Inter Variable","SF Pro Display",-apple-system,BlinkMacSystemFont,"Segoe UI",Roboto,sans-serif;line-height:1.6;letter-spacing:-.011em}
+.wrap{max-width:880px;margin:0 auto;padding:48px 24px 64px}
+.mono{font-family:"Berkeley Mono",ui-monospace,"SF Mono",Menlo,monospace}
+.eyebrow{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:12px;letter-spacing:.18em;text-transform:uppercase;color:var(--link);margin:0 0 10px;font-weight:510}
+h1{font-size:30px;line-height:1.14;margin:0 0 10px;font-weight:590;letter-spacing:-.022em;text-wrap:balance}
+.lede{color:var(--muted);font-size:14.5px;max-width:64ch;margin:0 0 6px}
+.mockbanner{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:12px;color:#f0cf4d;background:#F0BF0012;border:1px solid #F0BF0033;border-radius:8px;padding:9px 13px;margin:18px 0 0;line-height:1.5}
+h2{font-size:12px;letter-spacing:.14em;text-transform:uppercase;color:var(--muted);font-family:"Berkeley Mono",ui-monospace,monospace;margin:42px 0 14px;font-weight:510;display:flex;align-items:center;gap:10px}
+.card{background:var(--panel);border:1px solid var(--line);border-radius:16px;padding:6px 20px;box-shadow:0 3px 12px rgba(0,0,0,.09)}
+.row{display:grid;grid-template-columns:44px 1fr 130px 120px 90px;gap:12px;align-items:center;padding:13px 0;border-bottom:1px solid var(--line)}
+.row:last-child{border:none}
+.row.head{color:var(--faint);font-family:"Berkeley Mono",ui-monospace,monospace;font-size:10.5px;letter-spacing:.08em;text-transform:uppercase;padding:11px 0 9px}
+.rank{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:14px;color:var(--faint);font-weight:590}
+.row:nth-child(2) .rank{color:var(--yellow)}
+.handle{font-weight:590;font-size:14.5px;letter-spacing:-.011em;display:flex;align-items:center;gap:9px;flex-wrap:wrap}
+.you{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:10px;padding:1px 9px;border-radius:9999px;background:#5E6AD21f;color:var(--hover);border:1px solid #828FFF40;font-weight:510}
+.delta{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:15px;font-weight:590;font-variant-numeric:tabular-nums}
+.up{color:var(--green)} .flat{color:var(--faint)} .down{color:var(--red)}
+.pb{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:12px;color:var(--teal)}
+.streak{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:12px;color:var(--muted);text-align:right}
+.cap{color:var(--muted);font-size:12.5px;font-style:italic;margin:12px 2px 0;line-height:1.55}
+.cal .row{grid-template-columns:1fr 220px}
+.cal .prog{background:rgba(255,255,255,.04);border:1px solid var(--line);border-radius:6px;height:10px;overflow:hidden}
+.cal .prog span{display:block;height:100%;background:var(--yellow);border-radius:5px}
+.cal .meta{font-family:"Berkeley Mono",ui-monospace,monospace;font-size:11px;color:var(--faint);margin-top:4px}
+footer{margin-top:46px;padding:16px 18px;border:1px solid var(--line2);border-radius:12px;background:var(--elev);color:var(--body);font-size:13px;line-height:1.6}
+footer b{color:var(--ink)}
+.foot2{margin-top:14px;color:var(--faint);font-size:11.5px;font-family:"Berkeley Mono",ui-monospace,monospace;display:flex;justify-content:space-between;flex-wrap:wrap;gap:8px}
+@media(max-width:640px){.row{grid-template-columns:34px 1fr 90px 70px;font-size:13px}.streak{display:none}.row.head .streak{display:none}}
+</style>
+</head>
+<body>
+<div class="wrap">
+  <p class="eyebrow">Harris · Claude Code · community board</p>
+  <h1>Most improved — last 30 days</h1>
+  <p class="lede">Opt-in, pseudonymous, scores-only. Your sessions never leave your machine — the skill submits ~25 numbers, and the board ranks <b>improvement against your own past self</b>, never absolute grades.</p>
+  <div class="mockbanner">⚠ SEEDED MOCK — every row below except the labelled author row is synthetic demo data. No live service exists; nothing was collected. This page works offline from file://.</div>
+
+  <h2>Leaderboard <span style="color:var(--faint);text-transform:none;letter-spacing:0">— Δ composite vs own 30-day baseline</span></h2>
+  <div class="card">
+    <div class="row head"><span>#</span><span>handle</span><span>Δ 30 days</span><span>personal best</span><span class="streak">streak</span></div>
+    <div class="row"><span class="rank">1</span><span class="handle">quantum-badger</span><span class="delta up">+9.4</span><span class="pb">✦ new PB</span><span class="streak">6 wks</span></div>
+    <div class="row"><span class="rank">2</span><span class="handle">velvet-mongoose</span><span class="delta up">+7.1</span><span class="pb">✦ new PB</span><span class="streak">4 wks</span></div>
+    <div class="row"><span class="rank">3</span><span class="handle">midnight-pangolin</span><span class="delta up">+5.8</span><span class="pb">—</span><span class="streak">9 wks</span></div>
+    <div class="row"><span class="rank">4</span><span class="handle">turbo-heron</span><span class="delta up">+3.2</span><span class="pb">✦ new PB</span><span class="streak">3 wks</span></div>
+    <div class="row"><span class="rank">5</span><span class="handle">boulder-pusher <span class="you">author · real data · baseline day 1</span></span><span class="delta flat">+0.0</span><span class="pb">baseline set</span><span class="streak">1 wk</span></div>
+    <div class="row"><span class="rank">6</span><span class="handle">solar-lemur</span><span class="delta down">−1.9</span><span class="pb">—</span><span class="streak">7 wks</span></div>
+  </div>
+  <p class="cap">Deltas are computed locally by the skill against your own snapshots — the service never sees per-factor detail, only what you chose to submit. Gameable factors (commit cadence, push-through, delegation) are capped and blended before they can move a delta.</p>
+
+  <h2>Calibrating <span style="color:var(--faint);text-transform:none;letter-spacing:0">— building enough corpus to qualify</span></h2>
+  <div class="card cal">
+    <div class="row"><div><span class="handle">crimson-otter</span><div class="meta">31 / 50 sessions · 9 / 15 analyzed</div></div><div class="prog"><span style="width:62%"></span></div></div>
+    <div class="row"><div><span class="handle">paper-albatross</span><div class="meta">12 / 50 sessions · 3 / 15 analyzed</div></div><div class="prog"><span style="width:24%"></span></div></div>
+  </div>
+  <p class="cap">Scores from a small corpus aren't comparable to an 800-session one — rows join the board only past the minimum thresholds (straw-man: ≥50 sessions and ≥15 analyzed; final numbers pending calibration).</p>
+
+  <footer>
+    <b>This is a voluntary community game, not a performance instrument.</b> Participation is opt-in, handles are pseudonymous by default, submissions are a strict ~25-number allowlist (never transcripts, projects, or hours), any participant can delete their rows at any time, and this board must never be used in performance reviews, ranking discussions, or management reporting. If that framing ever breaks, the board shuts down.
+  </footer>
+  <div class="foot2">
+    <span>seeded mock · zero network requests · scores-only by design</span>
+    <span>myinsights leaderboard · pre-talk demo artifact</span>
+  </div>
+</div>
+</body>
+</html>

--- a/skills/myinsights/render_myinsights.py
+++ b/skills/myinsights/render_myinsights.py
@@ -104,67 +104,13 @@ def prompt_box(s): return f'<div class="prompt"><span class="pl">copyable prompt
 def scaffold_tag(s): return f'<span class="scaf">{E(str(s))}</span>' if s else ""
 
 # ================= SCORECARD =================
-# Deterministic formulas over quant.json. Each factor: name, score 0-100, provenance
-# ("full" n=sessions | "samp" n=facets), evidence, lever, weight (%). Targets for
-# cadence/delegation are stated in the evidence line — they are chosen yardsticks,
-# not industry benchmarks.
-def compute_scores():
-    fn = max(N_FACET, 1)
-    fric = dict(q.get("facet_frictions", []))
-    landed = outc.get("fully_achieved",0) + outc.get("mostly_achieved",0)
-    unclear = outc.get("unclear_from_transcript", 0)
-    buggy = fric.get("buggy_code", 0); wrong = fric.get("wrong_approach", 0)
-    commits = q.get("commits", 0); pushes = q.get("pushes", 0)
-    days = max(q.get("active_days", 1), 1)
-    cadence = commits / days
-    worktree = next((v for nm,v in areas if nm=="scratch/worktree"), 0)
-    agents = q.get("task_agent_sessions", 0)
-    errs = q.get("tool_errors", 0)
-    top_calls = sum(v for _,v in q.get("top_tools", [])) or 1
-    nf = max(N_FULL, 1)
-    F = []
-    F.append(dict(name="Ship cadence", score=min(100.0, 100*cadence/25), kind="full", w=10,
-        ev=f"{fmt(commits)} commits over {days} active days ≈ {cadence:.0f}/day, scored vs a 25/day target",
-        lever="Already elite — protect it; don't let review debt slow the pipeline."))
-    F.append(dict(name="Tool reliability", score=100*(1 - errs/top_calls), kind="full", w=5,
-        ev=f"{fmt(errs)} tool errors vs {fmt(top_calls)} top-12 tool calls (error rate is an upper bound — denominator excludes long-tail tools)",
-        lever="Mostly environmental; pre-flight known blockers (ports, auth, dead servers)."))
-    F.append(dict(name="Survival rate", score=100*(1 - unclear/fn), kind="samp", w=10,
-        ev=f"{unclear} of {fn} analyzed sessions died to output-token-limit errors",
-        lever="Budgeted runs with a forced reboot handoff before the ceiling."))
-    F.append(dict(name="Landing rate", score=100*landed/fn, kind="samp", w=20,
-        ev=f"{landed} of {fn} analyzed sessions ended fully or mostly achieved",
-        lever="Tighten done-criteria up front; keep the verify gate mandatory."))
-    F.append(dict(name="Approach accuracy", score=100*(1 - wrong/fn), kind="samp", w=15,
-        ev=f"wrong_approach flagged in {wrong} of {fn} analyzed sessions",
-        lever="5-minute feasibility probe + named fallback before coding against external systems."))
-    F.append(dict(name="Isolation discipline", score=100*worktree/nf, kind="full", w=10,
-        ev=f"{fmt(worktree)} of {fmt(nf)} sessions ran in isolated scratch/worktree areas",
-        lever="Default every multi-file build into a worktree off origin/main."))
-    F.append(dict(name="Clean first pass", score=100*(1 - buggy/fn), kind="samp", w=15,
-        ev=f"buggy_code flagged in {buggy} of {fn} analyzed sessions",
-        lever="Failing test (or assertion checklist) BEFORE editing 2+ files."))
-    F.append(dict(name="Push-through", score=100*pushes/max(commits,1), kind="full", w=10,
-        ev=f"{fmt(pushes)} pushes vs {fmt(commits)} commits — work that actually left the machine",
-        lever="Land or discard: fewer stranded local commits — unpushed work is invisible to teammates and at risk on a single machine."))
-    F.append(dict(name="Delegation leverage", score=min(100.0, 100*(agents/nf)/0.20), kind="full", w=5,
-        ev=f"{agents} of {fmt(nf)} sessions used task agents, scored vs a 20% target",
-        lever="Route search/mechanical work to haiku/sonnet subagents; keep Opus for judgment."))
-    total_w = sum(f["w"] for f in F)
-    composite = sum(f["score"]*f["w"] for f in F) / total_w
-    return sorted(F, key=lambda f: -f["score"]), composite
+# Formulas live in scorecard.py (shared with export_scores.py and any future
+# leaderboard client). variant="report" is bit-identical to the historical
+# inline implementation — leaderboard clamping only exists in variant="export".
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+from scorecard import compute_scores, grade_of, grade_color
 
-def grade_of(s):
-    for cut, letter in ((93,"A+"),(85,"A"),(78,"A−"),(70,"B+"),(62,"B"),(55,"B−"),(45,"C+"),(35,"C")):
-        if s >= cut: return letter
-    return "D"
-def grade_color(s):
-    if s >= 78: return C["green"]
-    if s >= 55: return C["blue"]
-    if s >= 35: return C["yellow"]
-    return C["red"]
-
-FACTORS, COMPOSITE = compute_scores()
+FACTORS, COMPOSITE = compute_scores(q, variant="report")
 COMP_GRADE = grade_of(COMPOSITE); COMP_COL = grade_color(COMPOSITE)
 
 def gauge():

--- a/skills/myinsights/scorecard.py
+++ b/skills/myinsights/scorecard.py
@@ -1,0 +1,100 @@
+#!/usr/bin/env python3
+"""scorecard.py — the deterministic 9-factor myinsights scorecard as an importable module.
+
+Extracted verbatim from render_myinsights.py so the renderer, the scores.json exporter,
+and any future leaderboard client share ONE formula. Two variants:
+
+- variant="report"  (FORMULA_VERSION_REPORT): bit-identical to the pre-refactor renderer.
+  push_through is unclamped (can exceed 100 if pushes > commits) and tool_reliability can
+  go negative if errors exceed counted calls — kept so local report numbers never shift
+  without a formula_version bump.
+- variant="export"  (FORMULA_VERSION_EXPORT): every factor clamped to [0, 100]. This is
+  the leaderboard/wire formula; scores.json uses it.
+
+Pure function of quant.json's dict — no I/O, no network, no globals.
+"""
+
+SCHEMA_VERSION = 1
+FORMULA_VERSION_REPORT = "1.0"
+FORMULA_VERSION_EXPORT = "1.0-clamped"
+
+# Grade band colors (Linear design tokens, shared with the renderer)
+_GREEN, _BLUE, _YELLOW, _RED = "#27A644", "#4EA7FC", "#F0BF00", "#EB5757"
+
+
+def _fmt(x):
+    return f"{x:,}" if isinstance(x, int) else x
+
+
+def compute_scores(q, variant="report"):
+    """Return (factors, composite). factors = list of dicts sorted best-first, each
+    {name, score, kind ('full'|'samp'), w (weight %), ev (evidence), lever (how to raise)}.
+    composite = weighted mean 0-100."""
+    n_facet = max(q.get("facet_n", q.get("facet_count", 0)), 1)
+    n_full = max(q.get("sessions", 0), 1)
+    outc = dict(q.get("facet_outcomes", []))
+    fric = dict(q.get("facet_frictions", []))
+    areas = q.get("top_project_areas", [])
+    landed = outc.get("fully_achieved", 0) + outc.get("mostly_achieved", 0)
+    unclear = outc.get("unclear_from_transcript", 0)
+    buggy = fric.get("buggy_code", 0)
+    wrong = fric.get("wrong_approach", 0)
+    commits = q.get("commits", 0)
+    pushes = q.get("pushes", 0)
+    days = max(q.get("active_days", 1), 1)
+    cadence = commits / days
+    worktree = next((v for nm, v in areas if nm == "scratch/worktree"), 0)
+    agents = q.get("task_agent_sessions", 0)
+    errs = q.get("tool_errors", 0)
+    top_calls = sum(v for _, v in q.get("top_tools", [])) or 1
+
+    F = []
+    F.append(dict(name="Ship cadence", score=min(100.0, 100 * cadence / 25), kind="full", w=10,
+        ev=f"{_fmt(commits)} commits over {days} active days ≈ {cadence:.0f}/day, scored vs a 25/day target",
+        lever="Already elite — protect it; don't let review debt slow the pipeline."))
+    F.append(dict(name="Tool reliability", score=100 * (1 - errs / top_calls), kind="full", w=5,
+        ev=f"{_fmt(errs)} tool errors vs {_fmt(top_calls)} top-12 tool calls (error rate is an upper bound — denominator excludes long-tail tools)",
+        lever="Mostly environmental; pre-flight known blockers (ports, auth, dead servers)."))
+    F.append(dict(name="Survival rate", score=100 * (1 - unclear / n_facet), kind="samp", w=10,
+        ev=f"{unclear} of {n_facet} analyzed sessions died to output-token-limit errors",
+        lever="Budgeted runs with a forced reboot handoff before the ceiling."))
+    F.append(dict(name="Landing rate", score=100 * landed / n_facet, kind="samp", w=20,
+        ev=f"{landed} of {n_facet} analyzed sessions ended fully or mostly achieved",
+        lever="Tighten done-criteria up front; keep the verify gate mandatory."))
+    F.append(dict(name="Approach accuracy", score=100 * (1 - wrong / n_facet), kind="samp", w=15,
+        ev=f"wrong_approach flagged in {wrong} of {n_facet} analyzed sessions",
+        lever="5-minute feasibility probe + named fallback before coding against external systems."))
+    F.append(dict(name="Isolation discipline", score=100 * worktree / n_full, kind="full", w=10,
+        ev=f"{_fmt(worktree)} of {_fmt(n_full)} sessions ran in isolated scratch/worktree areas",
+        lever="Default every multi-file build into a worktree off origin/main."))
+    F.append(dict(name="Clean first pass", score=100 * (1 - buggy / n_facet), kind="samp", w=15,
+        ev=f"buggy_code flagged in {buggy} of {n_facet} analyzed sessions",
+        lever="Failing test (or assertion checklist) BEFORE editing 2+ files."))
+    F.append(dict(name="Push-through", score=100 * pushes / max(commits, 1), kind="full", w=10,
+        ev=f"{_fmt(pushes)} pushes vs {_fmt(commits)} commits — work that actually left the machine",
+        lever="Land or discard: fewer stranded local commits — unpushed work is invisible to teammates and at risk on a single machine."))
+    F.append(dict(name="Delegation leverage", score=min(100.0, 100 * (agents / n_full) / 0.20), kind="full", w=5,
+        ev=f"{agents} of {_fmt(n_full)} sessions used task agents, scored vs a 20% target",
+        lever="Route search/mechanical work to haiku/sonnet subagents; keep Opus for judgment."))
+
+    if variant == "export":
+        for f in F:
+            f["score"] = max(0.0, min(100.0, f["score"]))
+
+    total_w = sum(f["w"] for f in F)
+    composite = sum(f["score"] * f["w"] for f in F) / total_w
+    return sorted(F, key=lambda f: -f["score"]), composite
+
+
+def grade_of(s):
+    for cut, letter in ((93, "A+"), (85, "A"), (78, "A−"), (70, "B+"), (62, "B"), (55, "B−"), (45, "C+"), (35, "C")):
+        if s >= cut:
+            return letter
+    return "D"
+
+
+def grade_color(s):
+    if s >= 78: return _GREEN
+    if s >= 55: return _BLUE
+    if s >= 35: return _YELLOW
+    return _RED

--- a/skills/myinsights/tests/fixtures/quant_fixture.json
+++ b/skills/myinsights/tests/fixtures/quant_fixture.json
@@ -1,0 +1,13 @@
+{
+  "sessions": 200,
+  "facet_n": 50,
+  "facet_outcomes": [["fully_achieved", 20], ["mostly_achieved", 15], ["unclear_from_transcript", 5], ["partially_achieved", 8], ["not_achieved", 2]],
+  "facet_frictions": [["buggy_code", 10], ["wrong_approach", 5]],
+  "commits": 100,
+  "pushes": 50,
+  "active_days": 10,
+  "top_project_areas": [["scratch/worktree", 120], ["projA", 30]],
+  "task_agent_sessions": 20,
+  "tool_errors": 20,
+  "top_tools": [["Bash", 800], ["Read", 200]]
+}

--- a/skills/myinsights/tests/test_payload_and_privacy.py
+++ b/skills/myinsights/tests/test_payload_and_privacy.py
@@ -1,0 +1,80 @@
+"""Payload allowlist, clamping, and no-network regression tests for the export path.
+
+Privacy contract: scores.json is the ONLY artifact allowed to leave the machine, and it
+may contain nothing beyond the allowlisted keys. NOTE — the PRD's literal validation
+grep ('ev|lever|...') would false-positive on substrings inside legitimate values
+("Delegation leverage", "formula_version"), so these tests check JSON KEY NAMES and
+forbidden top-level fields precisely instead.
+"""
+import json, os, re, sys, glob
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+sys.path.insert(0, SKILL)
+from export_scores import build_payload  # noqa: E402
+from scorecard import compute_scores  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "quant_fixture.json")
+
+
+def _all_keys(obj, acc):
+    if isinstance(obj, dict):
+        for k, v in obj.items():
+            acc.add(k); _all_keys(v, acc)
+    elif isinstance(obj, list):
+        for v in obj:
+            _all_keys(v, acc)
+    return acc
+
+
+def test_payload_allowlist_shape():
+    q = json.load(open(FIXTURE))
+    d = build_payload(q)
+    assert set(d) == {"schema_version", "formula_version", "corpus", "factors",
+                      "composite", "grade", "skill_version"}
+    assert set(d["corpus"]) == {"n_sessions", "n_facets", "active_days", "as_of"}
+    assert all(set(f) == {"name", "score", "kind", "w"} for f in d["factors"])
+    assert all(0 <= f["score"] <= 100 for f in d["factors"])
+    assert 0 <= d["composite"] <= 100
+
+
+def test_payload_contains_no_forbidden_keys():
+    q = json.load(open(FIXTURE))
+    keys = _all_keys(build_payload(q), set())
+    forbidden = {"ev", "lever", "top_project_areas", "by_hour", "busiest_days",
+                 "input_tokens", "output_tokens", "top_tools", "top_languages",
+                 "error_categories", "facet_outcomes", "facet_frictions"}
+    assert not (keys & forbidden), keys & forbidden
+
+
+def test_export_clamps_push_through_over_100():
+    q = json.load(open(FIXTURE))
+    q["pushes"] = 150  # > commits (100): report variant may exceed 100
+    rep, _ = compute_scores(q, variant="report")
+    exp, _ = compute_scores(q, variant="export")
+    rep_pt = next(f["score"] for f in rep if f["name"] == "Push-through")
+    exp_pt = next(f["score"] for f in exp if f["name"] == "Push-through")
+    assert rep_pt == 150.0, "report variant must stay unclamped (formula freeze)"
+    assert exp_pt == 100.0, "export variant must clamp to 100"
+
+
+def test_export_clamps_negative_reliability():
+    q = json.load(open(FIXTURE))
+    q["tool_errors"] = 2000  # > counted calls (1000): reliability goes negative
+    rep, _ = compute_scores(q, variant="report")
+    exp, _ = compute_scores(q, variant="export")
+    rep_tr = next(f["score"] for f in rep if f["name"] == "Tool reliability")
+    exp_tr = next(f["score"] for f in exp if f["name"] == "Tool reliability")
+    assert rep_tr == -100.0
+    assert exp_tr == 0.0
+
+
+def test_no_network_code_paths():
+    """No-config-no-network regression: no skill module may import a network-capable
+    library. The skill has no submission endpoint yet; nothing may phone home."""
+    banned = re.compile(
+        r"^\s*(import|from)\s+(urllib|requests|http\.client|httpx|socket|aiohttp)\b",
+        re.M)
+    for path in glob.glob(os.path.join(SKILL, "*.py")):
+        src = open(path).read()
+        assert not banned.search(src), f"network import found in {os.path.basename(path)}"

--- a/skills/myinsights/tests/test_scorecard_golden.py
+++ b/skills/myinsights/tests/test_scorecard_golden.py
@@ -1,0 +1,65 @@
+"""Golden-file test: scorecard.py (variant='report') must reproduce the pre-refactor
+inline renderer's scores exactly, for a synthetic checked-in fixture.
+
+Expected values are hand-derived from the disclosed formulas — if a formula changes,
+this test MUST fail until FORMULA_VERSION_* is bumped and the goldens are re-derived.
+"""
+import json, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+sys.path.insert(0, os.path.dirname(HERE))
+from scorecard import compute_scores, grade_of, SCHEMA_VERSION  # noqa: E402
+
+FIXTURE = os.path.join(HERE, "fixtures", "quant_fixture.json")
+
+# Hand-derived from the formulas (see scorecard.py):
+#   Ship cadence      100*(100/10)/25          = 40.0
+#   Tool reliability  100*(1-20/1000)          = 98.0
+#   Survival rate     100*(1-5/50)             = 90.0
+#   Landing rate      100*35/50                = 70.0
+#   Approach accuracy 100*(1-5/50)             = 90.0
+#   Isolation         100*120/200              = 60.0
+#   Clean first pass  100*(1-10/50)            = 80.0
+#   Push-through      100*50/100               = 50.0
+#   Delegation        min(100,100*(20/200)/.2) = 50.0
+GOLDEN = {
+    "Ship cadence": 40.0,
+    "Tool reliability": 98.0,
+    "Survival rate": 90.0,
+    "Landing rate": 70.0,
+    "Approach accuracy": 90.0,
+    "Isolation discipline": 60.0,
+    "Clean first pass": 80.0,
+    "Push-through": 50.0,
+    "Delegation leverage": 50.0,
+}
+GOLDEN_COMPOSITE = 70.9  # (40*10+98*5+90*10+70*20+90*15+60*10+80*15+50*10+50*5)/100
+GOLDEN_GRADE = "B+"
+
+
+def test_factor_scores_bit_identical():
+    q = json.load(open(FIXTURE))
+    factors, composite = compute_scores(q, variant="report")
+    got = {f["name"]: f["score"] for f in factors}
+    assert got == GOLDEN, f"scorecard drifted from golden: {got}"
+    assert abs(composite - GOLDEN_COMPOSITE) < 1e-9
+    assert grade_of(composite) == GOLDEN_GRADE
+
+
+def test_factors_sorted_and_weighted():
+    q = json.load(open(FIXTURE))
+    factors, _ = compute_scores(q, variant="report")
+    scores = [f["score"] for f in factors]
+    assert scores == sorted(scores, reverse=True), "factors must be ranked best-first"
+    assert sum(f["w"] for f in factors) == 100, "weights must total 100"
+    assert len(factors) == 9
+    assert SCHEMA_VERSION == 1
+
+
+def test_report_variant_matches_export_when_in_range():
+    """For a fixture where nothing exceeds [0,100], variants must agree exactly."""
+    q = json.load(open(FIXTURE))
+    rep, comp_r = compute_scores(q, variant="report")
+    exp, comp_e = compute_scores(q, variant="export")
+    assert [(f["name"], f["score"]) for f in rep] == [(f["name"], f["score"]) for f in exp]
+    assert comp_r == comp_e


### PR DESCRIPTION
Pre-talk slice of the opt-in Harris leaderboard (per PRD; no service, no
network — the M2 service is gated on a post-talk go decision + HR sign-off):

- scorecard.py: 9-factor formulas extracted into a shared module; report
  variant is bit-identical to the inline renderer (golden-tested), export
  variant clamps to [0,100] (formula_version 1.0-clamped)
- export_scores.py: strict-allowlist scores.json (schema/formula versions,
  corpus counts, 9 {name,score,kind,w} factors, composite, grade) — never
  evidence text, projects, hours, or tokens; local snapshots under data/
  give personal-best deltas offline
- leaderboard-mock.html: seeded, self-contained demo board (synthetic
  handles, most-improved deltas not absolute grades, calibrating section,
  not-for-performance-review footer); zero external requests
- SKILL.md: dormant opt-in submission section (payload-preview mandatory,
  no endpoint = no network)
- tests/: golden scorecard, payload allowlist, clamp, and no-network
  regression tests (8 passing) with a synthetic fixture

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
