### PR TITLE
docs: fix index docs count (67->68) after glm-zai page

### DIFF
--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Built by **Force Information Systems** · A **Harris Computer** Company · Part 
 | [Skills](docs/skills-ecosystem) | 52 | Production-ready custom `/commands` you can drop into any project |
 | [Templates](templates/CLAUDE) | 11 | Stack-specific CLAUDE.md files for TypeScript, React, Node, Python, Go, Rust, and more — plus a team onboarding template |
 | [Hooks](hooks/) | 28 | Guard-rail scripts for commits, builds, secrets, and session state — 11 auto-wired via the plugin, the rest opt-in |
-| [Docs](docs/guide) | 67 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 58 news deep-reads |
+| [Docs](docs/guide) | 68 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 58 news deep-reads |
 | [Examples](examples/) | 5 | Annotated real-world sessions showing workflows in action |
 | [Onboarding](onboarding/) | 6 | Step-by-step guides from installation to advanced usage |
 


### PR DESCRIPTION
Follow-up to #13. Bumps the index.md Docs count cell 67→68 so **Validate Count Claims** passes. One-line change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)