### PR TITLE
Continuous Development (ACT) guide + de-brand to Harris Computer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ node_modules/
 *.tmp
 .omc/
 response-to-*.md
+__pycache__/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 ## Project Basics
 
-This is a Markdown documentation project (Claude Code Playbook for Force Information Systems). There is no TypeScript, no build step, and no tests. Changes are primarily `.md` files.
+This is a Markdown documentation project (Claude Code Playbook). There is no TypeScript, no build step, and no tests. Changes are primarily `.md` files.
 
 ## Content Guidelines
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@
 <img src="https://img.shields.io/badge/52-Skills-5E6AD2?style=flat-square" alt="52 Skills"/>
 <img src="https://img.shields.io/badge/12-Templates-FC7840?style=flat-square" alt="12 Templates"/>
 <img src="https://img.shields.io/badge/28-Hooks-EB5757?style=flat-square" alt="28 Hooks"/>
-<img src="https://img.shields.io/badge/67-Docs-4EA7FC?style=flat-square" alt="67 Docs"/>
+<img src="https://img.shields.io/badge/69-Docs-4EA7FC?style=flat-square" alt="69 Docs"/>
 <img src="https://img.shields.io/badge/5-Examples-27A644?style=flat-square" alt="5 Examples"/>
 <img src="https://img.shields.io/badge/24-Anti--Patterns-F0BF00?style=flat-square" alt="24 Anti-Patterns"/>
 
@@ -68,7 +68,7 @@ After months of daily production use — debugging at 2am, shipping features acr
 <td width="50%">
 
 **Learn**
-- The **[docs site](https://ao92265.github.io/claude-code-playbook/)** — 67 guides organised by section, from [Getting Started](docs/getting-started.md) to enterprise governance, plus 58 news deep-reads
+- The **[docs site](https://ao92265.github.io/claude-code-playbook/)** — 69 guides organised by section, from [Getting Started](docs/getting-started.md) to enterprise governance, plus 58 news deep-reads
 - [24 prompt engineering patterns](docs/prompt-patterns.md) with copy-paste examples and a decision tree
 - [Quick-reference cheat sheet](docs/cheat-sheet.md) for commands, model routing, and session management
 - [Troubleshooting guide](docs/troubleshooting.md) with 15 common issues and diagnostic flowcharts
@@ -148,7 +148,7 @@ graph TB
 
 | Directory | Contents |
 |:----------|:---------|
-| **[docs/](docs/)** | 67 guides — patterns, configuration, architecture, enterprise, troubleshooting — plus [News & Research](docs/news/) with 58 deep-read article pages |
+| **[docs/](docs/)** | 69 guides — patterns, configuration, architecture, enterprise, troubleshooting — plus [News & Research](docs/news/) with 58 deep-read article pages |
 | **[skills/](skills/)** | 52 ready-to-use custom slash commands ([full reference below](#skills-reference)) |
 | **[hooks/](hooks/)** | 28 hook scripts — deterministic guard rails for commits, builds, secrets, and session state ([list below](#hooks)) |
 | **[templates/](templates/)** | 11 stack-specific CLAUDE.md files + a team onboarding template |
@@ -589,9 +589,28 @@ Never append to shared context files. Always replace the entire content and keep
 
 <br/>
 
+## Continuous Development — When the Loop Replaces the Ticket Queue
+
+The end-state this playbook builds towards: **ACT** (Autonomous Continuous Development) — an AI loop doing the day-to-day work of a Software Developer (Level 3) — scoped features, bug fixes, tests, PRs — **continuously, with a human in the loop** at the merge boundary. The human sets objectives and reviews merges; the loop does the L3 work in between.
+
+What makes it survivable is the **gate ladder** — quality enforcement ordered by what it costs and what it outlives:
+
+| Level | Gate | Survives running out of tokens? |
+|:------|:-----|:--------------------------------|
+| **L0** | Hooks + CI (deterministic, zero tokens) | **Yes** — they run regardless |
+| **L1** | Self-verification (run the tests, paste the exit code) | No — but L0 backstops it |
+| **L2** | Cross-model review (a different vendor's quota) | **Yes** — different provider, different limits |
+| **L3** | Human PR review, protected paths | Yes |
+
+Token limits are a *scheduled* failure mode for long loops, not a surprise. The playbook for it: continuous state handoffs so any fresh session resumes cold, cross-vendor fallback for reviews and grunt work, automated retry with backoff, budgeted stretches with a canary marker for context rot — and the one forbidden move: **never bypass a gate to keep moving**. Pause and queue instead.
+
+**[→ Read the full guide: Continuous Development (ACT)](docs/continuous-development.md)** — the operating model, the token-outage playbook in full, and the hard-won safety lessons (stage isolation, concurrency caps, sacrificial-repo certification).
+
+<br/>
+
 ## Documentation
 
-67 docs organised into sections on the **[docs site](https://ao92265.github.io/claude-code-playbook/)** — highlights by section:
+69 docs organised into sections on the **[docs site](https://ao92265.github.io/claude-code-playbook/)** — highlights by section:
 
 | Section | Key Pages |
 |:--------|:----------|
@@ -600,7 +619,7 @@ Never append to shared context files. Always replace the entire content and keep
 | **Configuration** | [Permissions](docs/permissions.md) · [MCP Servers](docs/mcp-servers.md) · [Model Comparison](docs/model-comparison.md) · [GLM on Claude Code (z.AI)](docs/glm-zai.md) · [Cost Guide](docs/cost-guide.md) · [Path-Scoped Rules](docs/path-scoped-rules.md) · [Auto Mode](docs/auto-mode.md) · [Verify Gate Hook](docs/verify-gate-hook.md) · [Daydream Hook](docs/daydream-hook.md) · [Audit Log Hook](docs/audit-log-hook.md) |
 | **Architecture** | [Harness](docs/harness.md) · [Harness Pattern](docs/harness-pattern.md) · [Steering Files](docs/steering-files.md) · [Setup Atlas](docs/setup-atlas.md) · [Setup Audit](docs/setup-audit.md) |
 | **Skills & Extensibility** | [Skills Ecosystem](docs/skills-ecosystem.md) · [Skills 2.0](docs/skills-v2.md) · [Plugin Authoring](docs/plugin-authoring.md) · [Agent Memory](docs/agent-memory.md) |
-| **Advanced** | [Agent Teams](docs/agent-teams.md) · [Multi-Model Orchestration](docs/multi-model-orchestration.md) · [BMad Autonomous Development](docs/bmad.md) · [Planning Blueprint](docs/planning-blueprint.md) · [Code Container](docs/code-container.md) · [Local Models](docs/local-models.md) · [Cost & Observability](docs/cost-and-observability.md) · [Knowledge & Context](docs/knowledge-and-context.md) · [Advanced Tool Use](docs/advanced-tool-use.md) · [SDK vs CLI](docs/sdk-vs-cli.md) · [Opus 4.7 Reference](docs/opus-4-7.md) |
+| **Advanced** | [Continuous Development (ACT)](docs/continuous-development.md) · [Agent Teams](docs/agent-teams.md) · [Multi-Model Orchestration](docs/multi-model-orchestration.md) · [BMad Autonomous Development](docs/bmad.md) · [Planning Blueprint](docs/planning-blueprint.md) · [Code Container](docs/code-container.md) · [Local Models](docs/local-models.md) · [Cost & Observability](docs/cost-and-observability.md) · [Knowledge & Context](docs/knowledge-and-context.md) · [Advanced Tool Use](docs/advanced-tool-use.md) · [SDK vs CLI](docs/sdk-vs-cli.md) · [Opus 4.7 Reference](docs/opus-4-7.md) |
 | **Enterprise** | [Enterprise Governance](docs/enterprise-governance.md) · [Regulated AI](docs/regulated-ai.md) · [Security Remediation](docs/security-remediation.md) · [Legacy Modernization](docs/legacy-modernization.md) · [GitHub Actions](docs/github-actions.md) · [Team Setup](docs/team-setup.md) · [Adoption Playbook](docs/adoption-playbook.md) · [Case Studies](docs/case-studies.md) |
 | **News & Research** | [April 2026 Briefing](docs/april-2026-briefing.md) · [58 deep-read article pages](docs/news/) across 9 categories |
 | **Help** | [FAQ](docs/faq.md) · [Troubleshooting](docs/troubleshooting.md) · [Comparison](docs/comparison.md) · [Codex Parity](docs/codex-parity.md) · [Awesome Claude Code](docs/awesome-claude-code.md) |
@@ -752,7 +771,7 @@ See **[CONTRIBUTING.md](CONTRIBUTING.md)** for detailed guidelines on contributi
 
 <br/>
 
-Built with hard-won lessons by **[Force Information Systems](https://www.force-uk.com)**, a **[Harris Computer](https://www.harriscomputer.com)** company, part of **[Constellation Software](https://www.csisoftware.com)**.
+Built with hard-won lessons at **[Harris Computer](https://www.harriscomputer.com)**, part of **[Constellation Software](https://www.csisoftware.com)**.
 
 <br/>
 

--- a/_config.yml
+++ b/_config.yml
@@ -29,7 +29,7 @@ color_scheme: harris
 mermaid:
   version: "10.9.1"
 
-footer_content: "Built by Force Information Systems &middot; Harris Computer &middot; Constellation Software. Licensed under MIT."
+footer_content: "Built at Harris Computer &middot; Constellation Software. Licensed under MIT."
 
 plugins:
   - jekyll-remote-theme

--- a/assets/images/readme/hero-dark.svg
+++ b/assets/images/readme/hero-dark.svg
@@ -55,5 +55,5 @@
   <rect x="300" y="228" width="600" height="2" rx="1" fill="url(#rule)"/>
 
   <text x="600" y="266" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12.5" font-weight="600" letter-spacing="2.4" fill="#62666D">SKILLS · HOOKS · TEMPLATES · MULTI-AGENT ORCHESTRATION · HARD-WON LESSONS</text>
-  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#62666D">Force Information Systems · A Harris Computer Company · Part of Constellation Software</text>
+  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#62666D">Harris Computer · Part of Constellation Software</text>
 </svg>

--- a/assets/images/readme/hero-light.svg
+++ b/assets/images/readme/hero-light.svg
@@ -49,5 +49,5 @@
   <rect x="300" y="228" width="600" height="2" rx="1" fill="url(#rule)"/>
 
   <text x="600" y="266" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12.5" font-weight="600" letter-spacing="2.4" fill="#8A8F98">SKILLS · HOOKS · TEMPLATES · MULTI-AGENT ORCHESTRATION · HARD-WON LESSONS</text>
-  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#8A8F98">Force Information Systems · A Harris Computer Company · Part of Constellation Software</text>
+  <text x="600" y="300" text-anchor="middle" font-family="-apple-system,BlinkMacSystemFont,'Segoe UI',Helvetica,Arial,sans-serif" font-size="12" fill="#8A8F98">Harris Computer · Part of Constellation Software</text>
 </svg>

--- a/docs/april-2026-briefing.md
+++ b/docs/april-2026-briefing.md
@@ -5,7 +5,7 @@ parent: "News & Research"
 ---
 # AI Engineering Briefing — April 2026
 
-**Author:** Alex O'Reilly, Force Information Systems
+**Author:** Alex O'Reilly, Harris Computer
 **Date:** 17 April 2026
 **Length:** ~20-minute read
 
@@ -764,7 +764,7 @@ Key sources linked inline in each section above:
 - Reza Rezvani, [The CLI vs MCP Debate Is Asking the Wrong Question]({{ site.baseurl }}/docs/news/cli-vs-mcp/)
 - Anthropic, [Introducing Claude Managed Agents]({{ site.baseurl }}/docs/news/managed-agents-launch/) — public beta
 
-**Contact:** Alex O'Reilly, Force Information Systems, aoreilly@harriscomputer.com
+**Contact:** Alex O'Reilly, Harris Computer, aoreilly@harriscomputer.com
 
 ---
 

--- a/docs/continuous-development.md
+++ b/docs/continuous-development.md
@@ -1,0 +1,120 @@
+---
+title: Continuous Development (ACT)
+parent: Advanced
+nav_order: 10
+---
+# Continuous Development — The ACT Pattern
+
+ACT (Autonomous Continuous Development) is the pattern this playbook has been building towards: an AI loop that **develops software continuously** — picking up well-scoped work, implementing it, verifying it, and raising PRs — with a **human in the loop** at the boundaries that matter.
+
+The bar it aims at is deliberately concrete: the day-to-day output of a **Software Developer (Level 3)** — well-scoped features, bug fixes, test coverage, refactors, and clean PRs against an existing codebase. Not architecture, not product discovery, not judgement calls about what to build. The human stops doing the L3 work and starts doing the parts that were never L3 in the first place: setting objectives, reviewing merges, and owning the consequences.
+
+That framing matters because it tells you exactly what to automate and what to protect:
+
+| | Who owns it |
+|:--|:--|
+| Picking up a scoped ticket, implementing, testing, opening a PR | The loop |
+| Deciding what the ticket should be | Human |
+| Verifying the change works (tests, build, gates) | The loop, mechanically |
+| Merging to main | Human (or human-set policy) |
+| Anything touching schema, secrets, prod, or compliance | Human, always |
+
+## The Operating Model
+
+```mermaid
+graph LR
+    O(["Objective"]) --> L["Loop:<br/>implement"]
+    L --> G{"Gates"}
+    G -->|"pass"| P["PR"]
+    G -.->|"fail"| L
+    P --> H{"Human<br/>review"}
+    H -->|"merge"| O
+    H -.->|"changes"| L
+
+    classDef info fill:#4EA7FC,stroke:#2E86D9,color:#0B1220
+    classDef primary fill:#5E6AD2,stroke:#4653B8,color:#FFFFFF
+    classDef warn fill:#F0BF00,stroke:#B89200,color:#221A00
+    classDef success fill:#27A644,stroke:#1F8737,color:#FFFFFF
+    classDef dark fill:#232326,stroke:#3E3E44,color:#F7F8F8
+    class O info
+    class L primary
+    class G warn
+    class P success
+    class H dark
+```
+
+Give the loop **objectives, not task lists**: what done looks like plus how to verify it, then let it run. Every iteration ends at a gate; every gate failure feeds back into the loop; nothing reaches a human that hasn't already survived the machinery below.
+
+## The Gate Ladder
+
+Quality gates are only useful if they hold when the model is tired, wrong, or absent. Order them by what they cost and what they survive:
+
+| Level | Gate | Token cost | Survives model outage? |
+|:------|:-----|:-----------|:-----------------------|
+| **L0 — Deterministic** | Hooks ([verify-gate](verify-gate-hook.md), [pre-commit guards](../hooks/README.md)) and CI (tests, lint, link/count validation) | Zero | **Yes** — they run regardless |
+| **L1 — Self-verification** | The loop proves its own work: run the tests, paste the exit code ([verification before completion](../skills/verification-before-completion/)) | Cheap | No, but L0 backstops it |
+| **L2 — Cross-model review** | A *different* vendor's model reviews the diff (Codex CLI, [multi-model orchestration](multi-model-orchestration.md)) | Separate quota | **Yes** — different provider, different limits |
+| **L3 — Human** | PR review, protected paths, sticky change-requests | Zero tokens | Yes |
+
+The design rule: **push as much enforcement as possible down to L0.** A Stop hook that blocks until `tsc` and the tests pass doesn't care how degraded the session is. CI that fails on a broken link or a drifted count doesn't need the model to remember anything. Every rule you can turn into a hook or a CI job is a rule the loop can no longer rationalise its way around — see [Steering Files](steering-files.md) and the [Harness](harness.md) guide for where each rule belongs.
+
+## When You Run Out of Tokens
+
+Long loops **will** hit limits — session caps, rate limits, provider outages, context windows. This isn't a hypothetical failure mode; it's a scheduled one. A continuous-development setup that only works while tokens flow isn't continuous. The playbook:
+
+### 1. The gates keep holding
+
+Nothing about L0 or L3 consumes model tokens. If the loop dies mid-task, the half-finished branch still can't merge: CI is red, hooks block, no human has approved. **Running out of tokens can stall progress; it must never lower quality.** That property comes entirely from putting enforcement in the harness instead of the prompt.
+
+### 2. State is written continuously, not at the end
+
+A loop that only summarises when it finishes loses everything when it's killed. Write state as you go, so any fresh session — or a different model entirely — resumes without re-deriving:
+
+- **Stop/PreCompact handoffs** ([stop-handoff.sh](../hooks/stop-handoff.sh), [precompact-handoff.sh](../hooks/precompact-handoff.sh)) — a deterministic "where I left off" file after every turn, re-injected at the next session start
+- **[/handoff](../skills/handoff/)** — structured close-out: done, remaining, decisions, gotchas
+- **[/reboot](../skills/reboot/)** — distil a bloated session into a clean re-prompt for a fresh context
+- Plans and decisions in files (`.omc/plans/`, PR descriptions, commit messages) — not in the conversation
+
+### 3. Fall back across vendors, not down in quality
+
+Different providers have different quotas. When the primary model hits its limit:
+
+- **Reviews** keep running through a second vendor's CLI (e.g. `codex exec --sandbox read-only` on the diff) — the review gate doesn't pause because Claude did
+- **Mechanical work** (boilerplate, bulk edits, drafts) routes to cheaper models; save the expensive tier for judgement
+- The **orchestration decisions** stay with whichever capable model you have — it's the worker fleet that's fungible, not the editor-in-chief
+
+### 4. Automate the retry, resume the task
+
+Transient outages (5xx, overload, rate-limit) shouldn't need a human watching. The [claude-retry wrapper](../scripts/claude-retry.sh) relaunches with backoff; the [/retry](../skills/retry/) skill resumes the cut-off task cleanly once the API recovers, instead of starting over.
+
+### 5. Budget the stretch, plant a canary
+
+Don't run to the wall and die mid-thought:
+
+- Cap unattended stretches (roughly ~20 tool calls), then emit a handoff — state, next step, verify command — *before* the ceiling, not after
+- In long loops, plant a **canary marker** (e.g. "begin every reply with 🐤"). When the marker silently disappears, the context has rotted: stop pushing, `/clear`, bootstrap from the handoff
+- Route by cost from the start ([model comparison](model-comparison.md), [cost guide](cost-guide.md)) so the budget lasts the objective
+
+### 6. Degrade gracefully: pause, never bypass
+
+The one forbidden move: disabling a gate to keep the loop moving. If tokens are gone and the fallbacks are exhausted, the correct behaviour is to **queue the work and stop** — handoff written, branch parked, CI red where it should be red. A stalled loop costs hours; a bypassed gate costs trust in every merge that followed it.
+
+## Hard-Won Safety Lessons
+
+Lessons from certifying an ACT loop against real repositories — each of these was learned the expensive way:
+
+| Lesson | Why |
+|:-------|:----|
+| **Run workers at concurrency 1 until proven** | Parallel agents burst straight into rate limits, which kills runs mid-write and looks like model failure |
+| **Isolate every stage** | A failed pipeline stage with push access once opened a garbage PR with thousands of unintended files. Stages get worktrees and scoped permissions, not repo-wide write |
+| **Certify on a sacrificial repo first** | Prove the merge policy, budget checks, and reviewer stages on a repo that can't hurt you before pointing the loop at anything live |
+| **Verify budget checks both ways** | A budget guard that false-blocks stalls the loop as surely as one that never fires overspends it — test both directions |
+| **The human merge stays** | Auto-merge is the last privilege the loop earns, long after it has earned everything else — and it's revoked on the first garbage PR |
+
+## Where To Go Next
+
+- [Verify Gate Hook](verify-gate-hook.md) — the L0 stop-gate implementation
+- [Multi-Model Orchestration](multi-model-orchestration.md) — cross-vendor review and delegation patterns
+- [BMad Autonomous Development](bmad.md) — an overnight sprint loop built on the same principles
+- [Agent Teams](agent-teams.md) — parallelism with worktree isolation
+- [Cost Guide](cost-guide.md) — making the budget last the objective

--- a/docs/harness.md
+++ b/docs/harness.md
@@ -158,7 +158,7 @@ If the answer to all of these is no, you probably do not need a harness. You nee
 
 ## FIS Defaults
 
-For Force Information Systems / Harris projects:
+For Harris projects:
 
 - **Day-to-day dev**: Claude Code (this playbook's defaults)
 - **CI/CD**: Claude Code headless (`claude --print`) or Agent SDK in GitHub Actions — see [github-actions.md](github-actions.md)

--- a/index.md
+++ b/index.md
@@ -8,7 +8,7 @@ nav_order: 0
 
 ### Stop prompting. Start engineering.
 
-Built by **Force Information Systems** · A **Harris Computer** Company · Part of **Constellation Software**
+Built at **Harris Computer** · Part of **Constellation Software**
 
 *Battle-tested patterns from 900+ sessions across production TypeScript projects.*
 
@@ -21,7 +21,7 @@ Built by **Force Information Systems** · A **Harris Computer** Company · Part 
 | [Skills](docs/skills-ecosystem) | 52 | Production-ready custom `/commands` you can drop into any project |
 | [Templates](templates/CLAUDE) | 11 | Stack-specific CLAUDE.md files for TypeScript, React, Node, Python, Go, Rust, and more — plus a team onboarding template |
 | [Hooks](hooks/) | 28 | Guard-rail scripts for commits, builds, secrets, and session state — 11 auto-wired via the plugin, the rest opt-in |
-| [Docs](docs/guide) | 68 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 58 news deep-reads |
+| [Docs](docs/guide) | 69 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 58 news deep-reads |
 | [Examples](examples/) | 5 | Annotated real-world sessions showing workflows in action |
 | [Onboarding](onboarding/) | 6 | Step-by-step guides from installation to advanced usage |
 


### PR DESCRIPTION
Two things:

**New: [Continuous Development (ACT)](docs/continuous-development.md)** — the pattern the playbook builds towards: an AI loop continuously doing Software Developer (Level 3) work — scoped features, fixes, tests, PRs — with a human in the loop at the merge boundary. Covers:
- The operating model (objective → loop → gates → PR → human) with diagram
- The **gate ladder**: L0 deterministic hooks/CI (zero tokens) → L1 self-verification → L2 cross-model review (separate vendor quota) → L3 human — ordered by what survives a token outage
- The **running-out-of-tokens playbook**: gates hold because they're in the harness, continuous state handoffs, cross-vendor fallback, automated retry, budgeted stretches + canary markers, and the forbidden move (never bypass a gate to keep moving — pause and queue)
- Hard-won safety lessons: concurrency 1 until proven, stage isolation (a failed stage once opened a garbage PR), sacrificial-repo certification, budget checks tested both ways, human merge stays

README gains a summary section with the gate-ladder table.

**De-brand:** Force Information Systems removed from all active surfaces (hero SVGs, footers, site config, CLAUDE.md, harness + briefing pages) → Harris Computer / Constellation Software. Historical launch article untouched by design.

Also fixes main's currently-red counts gate: #13 added the GLM page without bumping the doc counts; this PR takes them 67 → 69.

Verification: all 7 validate.yml jobs pass locally (0 failures); nav sanity clean (no duplicate sibling nav_order, ACT page parents to Advanced at free slot 10); zero `Force Information Systems` matches outside the historical article.

🤖 Generated with [Claude Code](https://claude.com/claude-code)