### PR TITLE
fix(myinsights): bucket git worktrees as scratch/worktree, not as a repo

### DIFF
--- a/skills/myinsights/gather_all.py
+++ b/skills/myinsights/gather_all.py
@@ -34,10 +34,13 @@ def area_of(path):
     if not path: return "other"
     p = path.lower()
     # collapse to a coarse area from the project path
+    # NOTE: the scratch/worktree test must run BEFORE the /repos/ test. Worktrees now live at
+    # ~/Repos/.agent-worktrees/<id>, so /repos/ matched first and bucketed them as a repo named
+    # ".agent-worktrees" — leaving scratch/worktree absent and Isolation discipline scoring 0.
+    if "scratchpad" in p or "/tmp/" in p or "agent-worktrees" in p: return "scratch/worktree"
     if "/repos/" in p:
         m = re.search(r"/repos/([^/]+)", p);
         if m: return m.group(1)[:28]
-    if "scratchpad" in p or "/tmp/" in p or "agent-worktrees" in p: return "scratch/worktree"
     _home = os.path.expanduser("~").rstrip("/")
     if p.endswith(_home.replace("/", "-").lower()) or p.rstrip("/").endswith(os.path.basename(_home).lower()): return "home (~)"
     m = re.search(r"([^/]+)/?$", path.rstrip("/"))

--- a/skills/myinsights/tests/test_area_classifier.py
+++ b/skills/myinsights/tests/test_area_classifier.py
@@ -1,0 +1,61 @@
+"""Regression test: gather_all.area_of must bucket worktrees as scratch/worktree.
+
+The original ordering tested "/repos/" before the scratch/worktree test. Git worktrees
+commonly live under a repo root (~/Repos/.agent-worktrees/<id>), so every worktree session
+was bucketed as a repo literally named ".agent-worktrees". scratch/worktree then never
+appeared in top_project_areas, and the Isolation discipline factor — which looks that name
+up by exact string — scored 0 for someone using worktrees correctly.
+
+Ordering is the contract here, not the individual branches. Keep the scratch test first.
+"""
+import importlib.util, os, sys
+
+HERE = os.path.dirname(os.path.abspath(__file__))
+SKILL = os.path.dirname(HERE)
+
+
+def _area_of():
+    """Load area_of without executing gather_all's module-level scan of ~/.claude."""
+    src = open(os.path.join(SKILL, "gather_all.py"), encoding="utf-8").read()
+    start = src.index("def area_of(")
+    end = src.index("\nfor ", start)
+    ns = {}
+    exec("import os, re\n" + src[start:end], ns)
+    return ns["area_of"]
+
+
+def test_worktree_under_repos_is_scratch_not_a_repo():
+    area_of = _area_of()
+    assert area_of("/Users/x/Repos/.agent-worktrees/abc-TASK-1") == "scratch/worktree"
+    assert area_of("/Users/x/repos/.agent-worktrees/abc") == "scratch/worktree"
+
+
+def test_scratchpad_and_tmp_still_scratch():
+    area_of = _area_of()
+    assert area_of("/tmp/claude-502/whatever") == "scratch/worktree"
+    assert area_of("/Users/x/Repos/proj/scratchpad/run") == "scratch/worktree"
+
+
+def test_ordinary_repo_still_resolves_to_its_name():
+    area_of = _area_of()
+    assert area_of("/Users/x/Repos/vanguardplanner") == "vanguardplanner"
+    assert area_of("/Users/x/Repos/vanguardplanner/src/app") == "vanguardplanner"
+
+
+def test_empty_and_unknown_paths():
+    area_of = _area_of()
+    assert area_of("") == "other"
+    assert area_of("/opt/somewhere/else") == "else"
+
+
+if __name__ == "__main__":
+    mod = sys.modules[__name__]
+    failed = 0
+    for name in [n for n in dir(mod) if n.startswith("test_")]:
+        try:
+            getattr(mod, name)()
+            print("PASS", name)
+        except Exception as exc:  # noqa: BLE001
+            failed += 1
+            print("FAIL", name, repr(exc))
+    raise SystemExit(1 if failed else 0)


### PR DESCRIPTION
## What

`area_of()` in `skills/myinsights/gather_all.py` tested `"/repos/"` before the scratch/worktree branch. Git worktrees live under a repo root (`~/Repos/.agent-worktrees/<id>`), so `/repos/` matched first and returned a "repo" literally named `.agent-worktrees`.

## Why it matters

`scratch/worktree` then never appeared in `top_project_areas`, and the **Isolation discipline** scorecard factor looks that exact string up — so it silently returned 0 for a user who does isolate their parallel work. On a live 204-session corpus with 35 worktree sessions the factor read 0.0 instead of 17.2; composite 72.9 → 74.6.

## Change

- Reorder the branches in `area_of()`.
- Add `skills/myinsights/tests/test_area_classifier.py` to pin the ordering and the cases that must keep working.

No doc/skill/hook count changes, so the `validate-counts` CI job is unaffected.

## Verification

```
8 passed, 0 failed   # existing myinsights tests
4 passed, 0 failed   # new test_area_classifier.py
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_014eH4epc9qt4Lf29RSSbeAG