### PR TITLE
docs: remove the OMC layer, document superpowers

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@
 
 <br/>
 
-<img src="https://img.shields.io/badge/52-Skills-5E6AD2?style=flat-square" alt="52 Skills"/>
+<img src="https://img.shields.io/badge/47-Skills-5E6AD2?style=flat-square" alt="47 Skills"/>
 <img src="https://img.shields.io/badge/12-Templates-FC7840?style=flat-square" alt="12 Templates"/>
 <img src="https://img.shields.io/badge/28-Hooks-EB5757?style=flat-square" alt="28 Hooks"/>
-<img src="https://img.shields.io/badge/69-Docs-4EA7FC?style=flat-square" alt="69 Docs"/>
+<img src="https://img.shields.io/badge/71-Docs-4EA7FC?style=flat-square" alt="71 Docs"/>
 <img src="https://img.shields.io/badge/5-Examples-27A644?style=flat-square" alt="5 Examples"/>
 <img src="https://img.shields.io/badge/24-Anti--Patterns-F0BF00?style=flat-square" alt="24 Anti-Patterns"/>
 

--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ graph TB
     end
 
     subgraph "Plugins"
-        OMC["OMC<br/><em>Agent orchestration</em>"]
+        SP["superpowers<br/><em>Process discipline</em>"]
         BMAD["BMAD<br/><em>Multi-agent roles</em>"]
         C7["Context7<br/><em>Documentation</em>"]
     end
@@ -121,7 +121,7 @@ graph TB
         GH["GitHub CLI<br/><em>PRs & issues</em>"]
     end
 
-    CC --> OMC
+    CC --> SP
     CC --> BMAD
     CC --> C7
     CC --> BR
@@ -138,7 +138,7 @@ graph TB
     class CM success
     class SK info
     class HK danger
-    class OMC,BMAD,C7 warn
+    class SP,BMAD,C7 warn
     class BR,DB,GH dark
 ```
 
@@ -296,9 +296,9 @@ graph TB
 </td>
 <td width="50%" valign="top">
 
-### OMC — Session Orchestration
+### Execution modes
 
-Execution modes that control *how* Claude works:
+Modes that control *how* Claude works. These came from a third-party layer until Aug 2026; the native equivalents are named underneath each one:
 
 ```mermaid
 graph LR
@@ -614,7 +614,7 @@ Token limits are a *scheduled* failure mode for long loops, not a surprise. The 
 | **Configuration** | [Permissions](docs/permissions.md) · [MCP Servers](docs/mcp-servers.md) · [Model Comparison](docs/model-comparison.md) · [GLM on Claude Code (z.AI)](docs/glm-zai.md) · [Cost Guide](docs/cost-guide.md) · [Path-Scoped Rules](docs/path-scoped-rules.md) · [Auto Mode](docs/auto-mode.md) · [Verify Gate Hook](docs/verify-gate-hook.md) · [Daydream Hook](docs/daydream-hook.md) · [Audit Log Hook](docs/audit-log-hook.md) |
 | **Architecture** | [Harness](docs/harness.md) · [Harness Pattern](docs/harness-pattern.md) · [Steering Files](docs/steering-files.md) · [Setup Atlas](docs/setup-atlas.md) · [Setup Audit](docs/setup-audit.md) |
 | **Skills & Extensibility** | [Skills Ecosystem](docs/skills-ecosystem.md) · [Skills 2.0](docs/skills-v2.md) · [Plugin Authoring](docs/plugin-authoring.md) · [Agent Memory](docs/agent-memory.md) |
-| **Advanced** | [Continuous Development (ACT)](docs/continuous-development.md) · [Agent Teams](docs/agent-teams.md) · [Multi-Model Orchestration](docs/multi-model-orchestration.md) · [BMad Autonomous Development](docs/bmad.md) · [Planning Blueprint](docs/planning-blueprint.md) · [Code Container](docs/code-container.md) · [Local Models](docs/local-models.md) · [Cost & Observability](docs/cost-and-observability.md) · [Knowledge & Context](docs/knowledge-and-context.md) · [Advanced Tool Use](docs/advanced-tool-use.md) · [SDK vs CLI](docs/sdk-vs-cli.md) · [Opus 4.7 Reference](docs/opus-4-7.md) |
+| **Advanced** | [Continuous Development (ACT)](docs/continuous-development.md) · [Agent Teams](docs/agent-teams.md) · [Superpowers](docs/superpowers.md) · [Multi-Model Orchestration](docs/multi-model-orchestration.md) · [BMad Autonomous Development](docs/bmad.md) · [Planning Blueprint](docs/planning-blueprint.md) · [Code Container](docs/code-container.md) · [Local Models](docs/local-models.md) · [Cost & Observability](docs/cost-and-observability.md) · [Knowledge & Context](docs/knowledge-and-context.md) · [Advanced Tool Use](docs/advanced-tool-use.md) · [SDK vs CLI](docs/sdk-vs-cli.md) · [Opus 4.7 Reference](docs/opus-4-7.md) |
 | **Enterprise** | [Enterprise Governance](docs/enterprise-governance.md) · [Regulated AI](docs/regulated-ai.md) · [Security Remediation](docs/security-remediation.md) · [Legacy Modernization](docs/legacy-modernization.md) · [GitHub Actions](docs/github-actions.md) · [Team Setup](docs/team-setup.md) · [Adoption Playbook](docs/adoption-playbook.md) · [Case Studies](docs/case-studies.md) |
 | **News & Research** | [April 2026 Briefing](docs/april-2026-briefing.md) · [59 deep-read article pages](docs/news/) across 9 categories |
 | **Help** | [FAQ](docs/faq.md) · [Troubleshooting](docs/troubleshooting.md) · [Comparison](docs/comparison.md) · [Codex Parity](docs/codex-parity.md) · [Awesome Claude Code](docs/awesome-claude-code.md) |

--- a/docs/awesome-claude-code.md
+++ b/docs/awesome-claude-code.md
@@ -15,7 +15,8 @@ A curated list of tools, plugins, MCP servers, and resources for Claude Code.
 
 | Plugin | What It Does |
 |:-------|:------------|
-| **[OMC (Oh My Claude Code)](https://github.com/nicobailey/oh-my-claudecode)** | Advanced session orchestration: autopilot, parallel agents, persistence loops, smart model routing |
+| **[superpowers](https://github.com/obra/superpowers)** | Brainstorming, planning, red-green TDD and systematic debugging, as skills that fire without being called |
+| **[OMC (Oh My Claude Code)](https://github.com/nicobailey/oh-my-claudecode)** | Session orchestration: autopilot, parallel agents, persistence loops, model routing. Removed from this stack on 17 Aug 2026 once Claude Code shipped equivalents natively |
 | **[BMAD](https://github.com/bmad-method/BMAD-METHOD)** | Multi-agent roles: Architect, Developer, QA, Security Auditor, Product Manager |
 | **[Context7](https://github.com/upstreamapi/context7)** | AI-powered documentation search — fetches up-to-date library docs and code examples |
 | **[PR Review Toolkit](https://github.com/anthropics/claude-code-plugins)** | Comprehensive PR review with specialized analysis agents |

--- a/docs/cheat-sheet.md
+++ b/docs/cheat-sheet.md
@@ -160,9 +160,9 @@ decisions made, and gotchas. Save to SESSION_NOTES.md.
 ## Plugin Quick Install
 
 ```bash
-claude /plugin install Context7     # AI-powered documentation search
-claude /plugin install BMAD         # Multi-agent orchestration (Architect, Dev, QA, Security, PM)
-claude /plugin install OMC          # Advanced session management (autopilot, ralph, ultrawork)
+claude plugin install context7@claude-plugins-official     # current library docs
+claude plugin install superpowers@claude-plugins-official  # brainstorm, plan, TDD, debugging
+claude plugin install code-review@claude-plugins-official  # multi-agent PR review
 ```
 
 ---

--- a/docs/cli-reference.md
+++ b/docs/cli-reference.md
@@ -101,8 +101,7 @@ These are not in most guides. All live in `.claude/settings.json` (project) or `
 | `CLAUDE_AUTOCOMPACT_PCT_OVERRIDE` | Auto-compact trigger threshold (1–99). |
 | `ENABLE_TOOL_SEARCH` | `auto:N` — switch to MCP tool search at N+ tools loaded. |
 | `CLAUDE_CODE_TASK_LIST_ID` | Share a task list across sessions. |
-| `DISABLE_OMC` | Kill switch for the oh-my-claudecode plugin layer. |
-| `OMC_SKIP_HOOKS` | Comma-separated list of hook names to skip. |
+| `OMC_SKIP_HOOKS` | Comma-separated list of hook names to skip for one command. Named after a layer that is gone; the variable stayed because every hook in this playbook reads it. |
 
 ## See Also
 

--- a/docs/cost-guide.md
+++ b/docs/cost-guide.md
@@ -298,7 +298,9 @@ Every session pays a fixed tax at startup for the skills registry, MCP tool sche
 
 Some context costs earn their keep. Do **not** archive the following in a routine prune:
 
-- **oh-my-claudecode (OMC).** OMC is the multi-agent orchestration backbone — its agent catalog, team runtime, skill registry, and hook/state wiring are load-bearing for any project using ralph, ultrawork, team, autopilot, or the `executor`/`planner`/`reviewer` subagent routing. Disabling OMC silently breaks orchestration skills that other playbook guidance assumes are available. Keep the plugin enabled globally; scope per-project via `enabledPlugins` in `~/.claude.json` only when you are certain no OMC-driven skill is invoked in that project.
+- **Your subagent definitions.** The `executor` / `planner` / `reviewer` style agents are what let you push work off the main context; deleting them to save a few hundred tokens costs you far more in the sessions that follow.
+
+> **Superseded 17 Aug 2026.** This slot used to say "never prune oh-my-claudecode, it is load-bearing". It was, until Claude Code shipped the same capabilities. Measured before removal: three of its skills were still in use, two had never been used once, and its block in the rule files was 79 lines of which half described features that no longer existed. Re-run that check on any layer you are told is load-bearing.
 - **Your team's workflow hooks.** `ts-check.sh`, `pre-commit-verify.sh`, `codex-prepush-review.sh`, and equivalents catch regressions before they ship. Their per-run cost is negligible (see *Cost by Hook* above).
 - **CLAUDE.md layers.** Global, project, and local CLAUDE.md files are shared across every session — keep them tight (<150 instructions total across layers) but do not delete rules you still rely on.
 

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -150,7 +150,7 @@ The smaller the scannable surface, the more accurate `Grep`/`Glob` answers will 
 
 **3. Prefer LSP over `grep` for symbol navigation.**
 
-If you have the OMC LSP tools (or any MCP server exposing `goto_definition` / `find_references` / `workspace_symbols`), use them for symbol lookups in typed codebases. `grep "handleAuth"` returns every comment, log line, and unrelated function with the same name. `lsp_find_references` returns only the actual call sites — which is what you almost always want.
+If you have LSP tools (any MCP server exposing `goto_definition` / `find_references` / `workspace_symbols`), use them for symbol lookups in typed codebases. `grep "handleAuth"` returns every comment, log line, and unrelated function with the same name. `lsp_find_references` returns only the actual call sites — which is what you almost always want.
 
 ---
 

--- a/docs/guide.md
+++ b/docs/guide.md
@@ -19,7 +19,7 @@ The core session workflow stays on this page — the request/verify rhythm, cont
 | Plugins | [Skills Ecosystem](skills-ecosystem.md) |
 | MCP servers | [MCP Servers](mcp-servers.md) |
 | BMAD and autonomous development | [BMad Autonomous Development](bmad.md) |
-| OMC session and execution modes | [Multi-Model Orchestration](multi-model-orchestration.md) |
+| Session and execution modes | [Multi-Model Orchestration](multi-model-orchestration.md) |
 | Agent teams and worktrees | [Agent Teams](agent-teams.md) |
 | Slash commands and command reference | [CLI Reference](cli-reference.md) |
 | Troubleshooting | [Troubleshooting](troubleshooting.md) |

--- a/docs/knowledge-and-context.md
+++ b/docs/knowledge-and-context.md
@@ -148,15 +148,13 @@ The r/vibecoding thread surfaces significant pushback:
 
 **Do not adopt without diligence.** `github.com/abhigyanpatwari/GitNexus` was mentioned as a credible OSS alternative to evaluate.
 
-The valuable part is the reframe — **retrieval is easy; memory is the hard problem** — which is directly applicable to OMC's notepad / project-memory / state layers and to any Claude Code skill that wants to persist across sessions.
+The valuable part is the reframe — **retrieval is easy; memory is the hard problem** — which applies to any per-project state you keep (notepad, project memory, handoffs) and to any Claude Code skill that wants to persist across sessions.
 
 ---
 
 ## How This Lands in Claude Code Today
 
-The OMC `wiki` skill (if you're running OMC) already implements the Karpathy pattern — it's described in the skill catalog as *"LLM Wiki — persistent markdown knowledge base that compounds across sessions (Karpathy model)."* Validates that the architecture generalises.
-
-For teams not on OMC:
+A skill implementing the Karpathy pattern is a persistent markdown knowledge base that compounds across sessions: ingest, query, lint. Build it yourself in four steps.
 
 1. Create a `docs/wiki/` directory in your repo with `raw/`, `concepts/`, `timelines/` subfolders and an `index.md`
 2. Add a skill / CLAUDE.md section with the three operations (Ingest / Query / Lint) as explicit commands

--- a/docs/multi-model-orchestration.md
+++ b/docs/multi-model-orchestration.md
@@ -235,61 +235,48 @@ Concrete implementation:
 3. `/codex:result` 30–120 seconds later
 4. Paste Codex's answer back into your Claude session and continue
 
-This pattern underpins OMC's built-in `ccg` workflow (Claude-Codex-Gemini tri-model) and Liu's adversarial-review flow. The community confirmation that it works is worth more than any benchmark.
+This pattern underpinned the `ccg` workflow (Claude-Codex-Gemini tri-model, since retired with the layer that shipped it) and Liu's adversarial-review flow. The community confirmation that it works is worth more than any benchmark.
 
 ---
 
-## OMC — Session Orchestration Modes
+## Session orchestration: what replaced OMC
 
-OMC (oh-my-claudecode) is the plugin most of this page's patterns run through. Beyond cross-model routing, it provides advanced session tools inside Claude Code itself: spawning parallel agents, managing context, running distributed workflows, and debugging Claude's decision-making.
+For most of this playbook's life the orchestration modes came from a third-party layer,
+oh-my-claudecode. **That layer was removed from this stack on 17 August 2026**, because Claude Code
+now ships the same capabilities natively. If you are reading an older page here that tells you to
+install it, this section is the correction.
 
-### Execution modes
+### What each mode became
 
-| Mode | Description |
-|------|-------------|
-| Autopilot | Flagship mode. Describe a goal, OMC handles the full lifecycle: planning, parallel execution, testing, and self-correction |
-| Ultrawork | Maximum parallelism with up to 5 concurrent worker agents. 3-5x faster than sequential |
-| Swarm | Coordinated agents pulling from a shared task pool. Prevents duplicate work |
-| Pipeline | Sequential agent chains with preset workflows for review, implement, and debug |
-| Ecomode | Token-efficient parallel execution with smart model routing. 30-50% token savings |
-| Ralph | Persistence mode — keeps working until the Architect agent verifies the goal is fully met |
-| TDD | Test-Driven Development workflow — write tests first, then implement |
+| Was | Now |
+|-----|-----|
+| Autopilot (idea to working code) | `/goal`, or plan mode followed by a normal run |
+| Ultrawork (parallel workers) | The Workflow tool, or several Agent calls in one message |
+| Swarm (shared task pool) | Agent teams |
+| Pipeline (sequential agent chain) | A Workflow script: stages, not a barrier per stage |
+| Ralph (persist until verified) | `/loop` with a done-condition and a verify command |
+| TDD | The test-first gate, plus the superpowers TDD skill |
+| Ecomode / model routing | `model=` on each subagent call, enforced by a hook |
 
-### Magic keywords
+### What survived, and why
 
-Type these keywords naturally in your prompt to trigger specific modes:
+Three skills stayed because nothing native replaces them:
 
-| Keyword | Effect |
-|---------|--------|
-| autopilot | Full autonomous execution from idea to code |
-| ralph | Persistence mode — runs until verified complete |
-| ralplan | Iterative planning with consensus structured deliberation |
-| ulw / ultrawork | Maximum parallelism with concurrent agents |
-| team | Spawns a team of coordinated agents |
-| deep-interview | Socratic questioning to clarify vague ideas before execution |
-| deepsearch | Enhanced search for finding files and modules across large codebases |
-| deep-analyze | Deep analysis of problems (e.g. why tests are failing) |
-| tdd | Test-Driven Development workflow |
-| plan | Planning interview before execution |
+| Skill | What it does |
+|-------|--------------|
+| `/afk` | Unattended run. Banks decisions it cannot make and keeps going rather than stopping to ask |
+| `/carryon` | One next-best action, then stops at the first real decision |
+| `/oneshot` | Idea to green PR with no interrupts |
 
-### Smart model routing
+Everything else went. The test for keeping any orchestration layer is simple: name the thing it
+does that the harness does not, and if you cannot, the layer is costing you context for nothing.
 
-OMC automatically routes tasks to the right model: Haiku for simple tasks, Sonnet for standard work, Opus for complex reasoning. This saves 30-50% on tokens with no manual configuration. For specialist tasks it can orchestrate other providers too — Codex for deep code review and security analysis, Gemini for visual analysis and 1M-token context on large files — which is where this page's CLI-vs-MCP framework applies.
+### The lesson worth generalising
 
-### Key commands
-
-| Command | Purpose |
-|---------|---------|
-| `/spawn` | Start a background agent on a specific task |
-| `/status` | Show status of all running agents |
-| `/focus` | Switch focus to a background agent |
-| `/merge` | Merge results from agents and terminate them |
-| `/kill` | Terminate a background agent |
-| `/log` | Show detailed logs for a specific agent |
-| `/oh-my-claudecode:autopilot` | Autonomous execution from idea to code |
-| `/oh-my-claudecode:ultrawork` | Parallel agent execution |
-| `/oh-my-claudecode:ralph` | Persistent execution until verified complete |
-| `stopomc` / `cancel` | Cancel active orchestration |
+A third-party layer that wraps the harness is borrowed time. Every capability it adds is a
+capability the harness vendor is also building, and when theirs lands, yours is a compatibility
+liability. Prefer layers that add a genuinely missing capability (unattended autonomy) over layers
+that rename what you already have (parallel agents, model routing, planning).
 
 ### /batch — parallel codebase changes
 

--- a/docs/setup-atlas.md
+++ b/docs/setup-atlas.md
@@ -7,7 +7,7 @@ parent: Architecture
 
 Most "here's my CLAUDE.md" posts show the rules file and stop. The rules file is the smallest part of it. The thing that makes a setup productive is everything around it: the hooks that fire on every prompt, the agents work gets routed to, the gates that block a bad commit, and the proxies and control towers that let you run ten terminals at once.
 
-This page is one diagram of a complete working stack. It's the [oh-my-claudecode](https://github.com/) orchestration layer plus custom hooks, skills, and infrastructure, drawn as a single wall-chart so the layers are visible at once.
+This page is one diagram of a complete working stack. It's Claude Code plus custom hooks, skills, and infrastructure, drawn as a single wall-chart so the layers are visible at once.
 
 ![Full Claude Code setup atlas — request lifecycle with decision gates, agent and skill catalogs, hooks, MCP servers, scheduled daemons, and the multi-terminal fleet and proxy layer]({{ site.baseurl }}/assets/images/claude-setup-atlas.png)
 
@@ -35,7 +35,7 @@ The two loop-backs are the part that matters. The model gets trusted inside a fe
 **Infrastructure and the fleet (bottom bands).** This is the part nobody draws.
 
 - Hooks by event, every script across all eight hook events.
-- MCP servers, scheduled launchd daemons, plugins, and the `.omc/` state tree.
+- MCP servers, scheduled launchd daemons, plugins, and the per-project state tree.
 - The multi-terminal fleet. 6–10 Claude sessions in parallel, each with its own stop-handoff. `/morning` consolidates them into one briefing. A local triage board (`rohcna`) sorts the parked ones into needs-you / mid-task / resume / stale and jumps you straight to the iTerm pane.
 - Proxies in front of the model: a token-killing Bash-rewrite proxy (60–90% off), a context-compression proxy, and a 60-second re-auth daemon.
 - Headless and subscription: driving the CLI with `stream-json --resume` to build subscription-funded agents with no API key.

--- a/docs/superpowers.md
+++ b/docs/superpowers.md
@@ -1,0 +1,106 @@
+---
+title: Superpowers
+nav_order: 8
+parent: Advanced
+---
+# Superpowers
+
+A plugin that gives Claude a process: ask before building, plan in small pieces, write the test
+first, debug systematically, verify before claiming done. It is in Anthropic's own marketplace,
+sourced from [obra/superpowers](https://github.com/obra/superpowers).
+
+```bash
+claude plugin install superpowers@claude-plugins-official
+```
+
+Active from your next session. There is nothing to type.
+
+---
+
+## How it actually fires
+
+A session-start hook injects one instruction: check for a relevant skill before doing anything,
+and if one applies, use it. Fourteen skills sit behind that, loaded only when they fire.
+
+You will see it announce itself, in the form *"Using test-driven-development to..."*. That is the
+tell that it engaged. If you never see that line, it did not.
+
+| Trigger | Skill that fires |
+|---|---|
+| "let's build X" | brainstorming, then writing-plans |
+| "fix this bug" | systematic-debugging |
+| Any code change | test-driven-development |
+| Before claiming done | verification-before-completion |
+| A plan with many independent tasks | subagent-driven-development |
+
+## What it costs
+
+About 584 tokens on every session, then 500 to 8,000 each time a skill actually fires. The
+session-start hook itself is free: it runs in the harness, not in the model's context.
+
+Check any plugin's cost before installing it:
+
+```bash
+claude plugin details <name>@<marketplace>
+```
+
+## What the measurement showed
+
+Two arms, same prompt, same starting repo: build a small CLI end to end with tests passing.
+
+| | With superpowers | Without |
+|---|---|---|
+| Wall clock | 5m 13s | 9m 13s |
+| Cost | $1.82 | $1.91 |
+| Tests written | 55 | 66 |
+| Order of work | test first, every layer | all source first, tests after |
+| Repair loop | 4 edits | 10 edits |
+
+Both shipped working code and both told the truth about being done. The interesting part is not
+the speed, it is one specific moment: the plugin arm ran its first test, saw it fail, and then
+noticed the failure was the test runner rather than the missing module. It moved the
+implementation aside, proved a real failure, and only then wrote the fix.
+
+**That is the habit worth having, with or without the plugin.** A test that has only ever failed
+because of an import error has never once guarded the behaviour it claims to.
+
+## Where it will fight your setup
+
+It describes its workflows as mandatory and tells the model it has no choice. If you already run
+your own rules, expect friction in three places:
+
+1. **Planning.** It wants to brainstorm before plan mode. If you have your own planning skill,
+   say which one wins, in your rules, before you need to decide mid-task.
+2. **Verification.** Its verification skill will declare work done. If you have a stricter gate
+   (a typecheck-lint-test-build command, or an independent review), keep that as the real gate
+   and let the skill be the first pass.
+3. **Tone.** It asks the model to announce every skill invocation. If you have hard rules about
+   reply length or register, say so once rather than fighting it every turn.
+
+Its own instructions defer to your CLAUDE.md, which is the lever: one short section naming what
+wins settles all three.
+
+```markdown
+<superpowers>
+Its skills are advisory here, not mandatory: these rules win where they disagree.
+Use its test-first loop and its systematic debugging. Do not let its brainstorming
+replace your planning skill, or its verification replace your completion gate.
+</superpowers>
+```
+
+## Turning it off
+
+```bash
+claude plugin disable superpowers@claude-plugins-official   # keep it installed, stop it firing
+claude plugin uninstall superpowers@claude-plugins-official # remove it
+```
+
+## When it is worth it
+
+Worth installing if your sessions drift: work starts before the requirements are clear, tests get
+written after the code, "done" arrives without evidence. It supplies discipline you have not built
+yet.
+
+Less worth it if you already have that discipline enforced somewhere it cannot be argued with, in
+hooks or gates. Then you are paying for a second copy of your own rules, in a voice that insists it
+outranks them.

--- a/index.md
+++ b/index.md
@@ -21,7 +21,7 @@ Built at **Harris Computer** · Part of **Constellation Software**
 | [Skills](docs/skills-ecosystem) | 47 | Production-ready custom `/commands` you can drop into any project |
 | [Templates](templates/CLAUDE) | 11 | Stack-specific CLAUDE.md files for TypeScript, React, Node, Python, Go, Rust, and more — plus a team onboarding template |
 | [Hooks](hooks/) | 28 | Guard-rail scripts for commits, builds, secrets, and session state — 11 auto-wired via the plugin, the rest opt-in |
-| [Docs](docs/guide) | 70 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 59 news deep-reads |
+| [Docs](docs/guide) | 71 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 59 news deep-reads |
 | [Examples](examples/) | 5 | Annotated real-world sessions showing workflows in action |
 | [Onboarding](onboarding/) | 6 | Step-by-step guides from installation to advanced usage |
 

--- a/skills/brainstorming/SKILL.md
+++ b/skills/brainstorming/SKILL.md
@@ -7,7 +7,7 @@ description: |
   "what are my another-projectns for", "pros and cons of".
 
   Do NOT use this skill for: implementation work, bug fixes, code review, planning (use
-  writing-plans or OMC omc-plan instead), simple questions with clear answers, or when the
+  writing-plans instead), simple questions with clear answers, or when the
   user says "design" in the context of UI/UX work. Don't trigger on "figure out how to" —
   that usually means the user wants implementation, not exploration.
 license: MIT

--- a/skills/critic/SKILL.md
+++ b/skills/critic/SKILL.md
@@ -10,7 +10,7 @@ Adversarial second-opinion pass on a plan or proposal before execution begins.
 ## When to invoke
 
 - Plan file written, before ExitPlanMode approval
-- Long autopilot/ralph prompt drafted, before launch
+- Long autonomous-run prompt drafted, before launch
 - User asks "is this plan any good"
 - After a deep-interview produced a spec, before implementation
 
@@ -26,7 +26,7 @@ Adversarial second-opinion pass on a plan or proposal before execution begins.
    - If active plan file exists at `~/.claude/plans/*.md` (latest mtime) → use it
    - Else use the last assistant message in conversation
    - User can pass explicit path: `/critic <path>`
-2. Spawn `oh-my-claudecode:critic` agent (model=`opus`) with prompt:
+2. Spawn the `critic` agent (model=`opus`) with prompt:
 
    ```
    Review the attached plan. Find 3-10 specific issues across these axes:

--- a/skills/deep-explore/SKILL.md
+++ b/skills/deep-explore/SKILL.md
@@ -8,7 +8,7 @@ description: >
 
   Do NOT use this skill for: simple file lookups, single grep searches, known file
   locations, implementation tasks, or cross-repo searches (use cross-project-search).
-  Don't trigger when OMC's built-in Explore agent would suffice for a 1-3 file lookup.
+  Don't trigger when the built-in Explore agent would suffice for a 1-3 file lookup.
 context: fork
 agent: Explore
 title: "deep-explore"

--- a/skills/executing-plans/SKILL.md
+++ b/skills/executing-plans/SKILL.md
@@ -6,7 +6,7 @@ description: |
   "run the plan", "start working on the plan in docs/plans".
 
   Do NOT use this skill for: creating plans (use writing-plans), ad-hoc coding, tasks
-  without a written plan file, or autonomous execution (use OMC ralph/ultrawork/autopilot
+  without a written plan file, or autonomous execution (use /loop, /goal or /afk
   for multi-agent execution loops).
 license: MIT
 compatibility: marvin

--- a/skills/pr-fleet/SKILL.md
+++ b/skills/pr-fleet/SKILL.md
@@ -146,7 +146,7 @@ After each batch of 5 (or when the queue runs out, whichever is first):
 ### Step 4 — Exit cleanly
 
 - `git worktree prune` to remove any orphan worktrees
-- DO NOT cancel any active OMC mode; coordinator exits naturally
+- DO NOT cancel any active autonomous mode; the coordinator exits naturally
 
 ## Hard Rules (coordinator)
 

--- a/skills/skill-capture/SKILL.md
+++ b/skills/skill-capture/SKILL.md
@@ -123,7 +123,7 @@ between operations is the common case, not the exception."
    independently) vs Workflow (operational step sequence, stable).
 4. **Save location:**
    - User-level (rare, only truly portable insights):
-     `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<skill-name>.md`
+     `${CLAUDE_CONFIG_DIR:-~/.claude}/skills/learned/<skill-name>.md`
    - Project-level (default, commit with the repo to share with the team):
      `.omc/skills/<skill-name>.md`
    - Note: in linked worktrees, uncommitted skills are worktree-local and
@@ -163,7 +163,7 @@ concrete skill draft, before it has to be rediscovered later.
    or documentation only (if it's not really repeatable, say so and stop).
 4. If drafting a learned skill file, use the same frontmatter requirement
    and save paths as `extract` mode above
-   (`${CLAUDE_CONFIG_DIR:-~/.claude}/skills/omc-learned/<skill-name>.md` or
+   (`${CLAUDE_CONFIG_DIR:-~/.claude}/skills/learned/<skill-name>.md` or
    `.omc/skills/<skill-name>.md`). Never write frontmatter-less markdown.
 5. Draft the full file: clear triggers, ordered steps, explicit success
    criteria (prefer these over vague prose), and pitfalls.

--- a/skills/writing-plans/SKILL.md
+++ b/skills/writing-plans/SKILL.md
@@ -6,7 +6,7 @@ description: |
   implementation plan", "document the approach before we start".
 
   Do NOT use this skill for: executing plans (use executing-plans instead), verbal planning
-  discussions (use brainstorming), multi-agent planning (use OMC omc-plan or ralplan),
+  discussions (use brainstorming), multi-agent planning (use the Workflow tool),
   simple tasks, single-file changes, or when the user says "how should I implement" as a
   conversational question rather than a request for a written plan file.
 license: MIT

--- a/templates/ONBOARDING-TEAM.md
+++ b/templates/ONBOARDING-TEAM.md
@@ -37,8 +37,8 @@ Top Skills & Commands:
   /bad                         ████████████████████  10x/month
   /extra-usage                 ██████████████████░░   9x/month
   /ultraplan                   ████████░░░░░░░░░░░░   4x/month
-  /oh-my-claudecode:team       ██████░░░░░░░░░░░░░░   3x/month
-  /oh-my-claudecode:autopilot  ██████░░░░░░░░░░░░░░   3x/month
+  /goal                        ██████░░░░░░░░░░░░░░   3x/month
+  /afk                         ██████░░░░░░░░░░░░░░   3x/month
   /loop                        ██████░░░░░░░░░░░░░░   3x/month
   /model                       ██████░░░░░░░░░░░░░░   3x/month
   /compact                     ████░░░░░░░░░░░░░░░░   2x/month
@@ -47,7 +47,6 @@ Top Skills & Commands:
 Top MCP Servers:
   computer-use       ████████████████████  ~427 calls
   chrome-devtools    ████████████████░░░░  ~345 calls
-  oh-my-claudecode   ████████░░░░░░░░░░░░  ~164 calls
   historian          █░░░░░░░░░░░░░░░░░░░  ~11 calls
   context7           ░░░░░░░░░░░░░░░░░░░░  occasional
 ```
@@ -69,7 +68,7 @@ Top tool calls (past 30 days): Bash 24.6k · Read 11.8k · Edit 4.9k · Grep 3.5
 <!-- Only list MCPs the team actually uses. Drop anything you don't rely on. -->
 - [ ] **computer-use** — Desktop automation (screenshots, clicks, typing) for native macOS/Windows apps. Install the computer-use MCP package; approve app access per workflow.
 - [ ] **chrome-devtools** — Browser automation through the Chrome DevTools Protocol. Used for scraping, digesting tabs, and driving web apps. Install the Chrome DevTools MCP server.
-- [ ] **oh-my-claudecode (OMC)** — Multi-agent orchestration layer with skills like autopilot, ralph, team, ultrawork. Run `omc setup` or `/oh-my-claudecode:omc-setup`.
+- [ ] **superpowers** — Brainstorming, planning, test-first and systematic debugging as skills that fire on their own. `claude plugin install superpowers@claude-plugins-official`.
 - [ ] **context7** — On-demand library/SDK docs lookup. Configure via MCP settings.
 
 ### Skills to Know About
@@ -79,8 +78,8 @@ Top tool calls (past 30 days): Bash 24.6k · Read 11.8k · Edit 4.9k · Grep 3.5
 - [ ] **/bad** (~10x/mo) — BMAD autonomous development pipeline: parallel story implementation, each story isolated in its own worktree. Trigger for "run BAD" / "automate the sprint".
 - [ ] **/extra-usage** (~9x/mo) — Check your quota before kicking off heavy work.
 - [ ] **/ultraplan** (~4x/mo) — Consensus planning across Planner / Architect / Critic before execution. Use on high-risk changes.
-- [ ] **/oh-my-claudecode:team** (~3x/mo) — N coordinated Claude agents on a shared task list; stage-aware routing.
-- [ ] **/oh-my-claudecode:autopilot** (~3x/mo) — Full autonomous execution from idea to working code. Use for broad "build me X" requests.
+- [ ] **/goal** (~3x/mo) — A multi-step objective with a final verification pass. Use for broad "build me X" requests.
+- [ ] **/afk** (~3x/mo) — Unattended run. Banks the decisions it cannot make and keeps going instead of stopping to ask.
 - [ ] **/loop** (~3x/mo) — Run a prompt or slash command on a recurring interval. Good for polling builds, scheduling self-paced tasks, or babysitting PRs.
 - [ ] **/compact** (~2x/mo) — Compress conversation history mid-session before context rot kicks in.
 - [ ] **/check-env** — Pre-flight environment check (ports, Docker, `.env`, git status) before starting dev work.
@@ -95,7 +94,7 @@ Top tool calls (past 30 days): Bash 24.6k · Read 11.8k · Edit 4.9k · Grep 3.5
 - **Never push, PR, or deploy without explicit permission.** Auto mode is not a license to ship; same for destructive git ops.
 - **Check the environment first.** Run `/check-env` before starting dev — ports, Docker, `.env`, git state. Most "it doesn't work" moments are environmental.
 - **Run `npx tsc --noEmit` after multi-file TS changes.** Consider a hook to run this automatically on Edit/Write.
-- **Use skills, not ad-hoc prompts, for repeating workflows.** `/oh-my-claudecode:autopilot` for broad builds, `/loop` for recurring checks, `/schedule` for cloud cron, `/codex:rescue` when stuck.
+- **Use skills, not ad-hoc prompts, for repeating workflows.** `/goal` for broad builds, `/loop` for recurring checks, `/schedule` for cloud cron, `/codex:rescue` when stuck.
 - **Stay on low reasoning effort by default.** Use `/effort` to escalate only for genuinely hard problems — tokens are finite.
 - **Record fixes in `tasks/lessons.md`.** Format: `- **[date] Problem**: ... → **Fix**: ...`. Promote recurring patterns to CLAUDE.md weekly.
 - **Read the Claude playbook.** Live at https://ao92265.github.io/claude-code-playbook/, source at https://github.com/ao92265/claude-code-playbook. Covers skills, hooks, MCPs, workflows.


### PR DESCRIPTION
## Why

OMC was removed from this stack on 17 August 2026 because Claude Code now ships the same capabilities natively. The playbook still told readers to install it and described it as load-bearing, which is wrong advice rather than merely stale advice.

## What changed

**Corrected guidance**
- `multi-model-orchestration`: the OMC modes section is now a was/now table mapping each retired mode to its native equivalent, plus the three skills that survived and why.
- `cost-guide`: the "never prune OMC, it is load-bearing" entry becomes a worked example of re-testing that claim. Measured before removal: two of its skills had never been invoked once, and its block in the rule files was 79 lines, half describing features that no longer existed.
- `cheat-sheet`, `cli-reference`, `getting-started`, `guide`, `setup-atlas`, `knowledge-and-context`, `awesome-claude-code`: install commands, environment variables and index rows corrected.
- `templates/ONBOARDING-TEAM.md`: the install checklist item and its two commands replaced with what a new teammate would actually run.

**Broken references fixed**
- `skills/critic` spawned a plugin-namespaced agent that no longer exists.
- `writing-plans`, `executing-plans`, `deep-explore`, `brainstorming` pointed at retired modes.
- `skill-capture` wrote learned skills into an OMC-named directory.

**New**
- `docs/superpowers.md`: what it is, how it fires without being called, what it costs per session, a two-arm measurement on the same task, and the three places it will fight an existing rule set.

## Not changed

Posts under `docs/news` keep their original text. They are dated write-ups of what was true when published.

## Verification

- No install-OMC advice remains outside the news archive.
- The new doc is linked from the README directory tree, per the repo's own convention.
