### PR TITLE
Add the Matcha delegation lane: skill, three hooks, and a guide

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@
 
 [![Quick Start](https://img.shields.io/badge/Quick_Start-5E6AD2?style=for-the-badge&logo=rocket&logoColor=white)](#quick-start)
 [![Docs Site](https://img.shields.io/badge/Docs_Site-00B8CC?style=for-the-badge&logo=book&logoColor=white)](https://ao92265.github.io/claude-code-playbook/)
-[![Skills](https://img.shields.io/badge/Skills-47_included-5E6AD2?style=for-the-badge&logo=puzzle-piece&logoColor=white)](#skills-reference)
-[![Hooks](https://img.shields.io/badge/Hooks-28_included-EB5757?style=for-the-badge&logoColor=white)](#hooks)
+[![Skills](https://img.shields.io/badge/Skills-48_included-5E6AD2?style=for-the-badge&logo=puzzle-piece&logoColor=white)](#skills-reference)
+[![Hooks](https://img.shields.io/badge/Hooks-31_included-EB5757?style=for-the-badge&logoColor=white)](#hooks)
 [![CI](https://img.shields.io/github/actions/workflow/status/ao92265/claude-code-playbook/validate.yml?style=for-the-badge&label=CI&logo=github)](https://github.com/ao92265/claude-code-playbook/actions/workflows/validate.yml)
 [![License](https://img.shields.io/badge/License-MIT-27A644?style=for-the-badge&logo=opensourceinitiative&logoColor=white)](LICENSE)
 [![Stars](https://img.shields.io/github/stars/ao92265/claude-code-playbook?style=for-the-badge&logo=github&color=F0BF00)](https://github.com/ao92265/claude-code-playbook/stargazers)
@@ -20,10 +20,10 @@
 
 <br/>
 
-<img src="https://img.shields.io/badge/47-Skills-5E6AD2?style=flat-square" alt="47 Skills"/>
+<img src="https://img.shields.io/badge/48-Skills-5E6AD2?style=flat-square" alt="48 Skills"/>
 <img src="https://img.shields.io/badge/12-Templates-FC7840?style=flat-square" alt="12 Templates"/>
-<img src="https://img.shields.io/badge/28-Hooks-EB5757?style=flat-square" alt="28 Hooks"/>
-<img src="https://img.shields.io/badge/71-Docs-4EA7FC?style=flat-square" alt="71 Docs"/>
+<img src="https://img.shields.io/badge/31-Hooks-EB5757?style=flat-square" alt="31 Hooks"/>
+<img src="https://img.shields.io/badge/72-Docs-4EA7FC?style=flat-square" alt="72 Docs"/>
 <img src="https://img.shields.io/badge/5-Examples-27A644?style=flat-square" alt="5 Examples"/>
 <img src="https://img.shields.io/badge/24-Anti--Patterns-F0BF00?style=flat-square" alt="24 Anti-Patterns"/>
 
@@ -404,6 +404,7 @@ Every skill is a drop-in `/command` that teaches Claude a specific workflow. All
 | **[research-only](skills/research-only/)** | Enforces strict analysis-only mode: no Edit/Write tools, findings as markdown only | Investigations that must not touch code |
 | **[multiask](skills/multiask/)** | Cross-checks an answer across multiple AI CLIs in parallel with adversarial review | High-stakes decisions: security, prod incidents, irreversible changes |
 | **[loom-analyze](skills/loom-analyze/)** | Downloads a Loom share URL and produces a transcript plus keyframes for analysis | Turning recorded walkthroughs into actionable notes |
+| **[matcha](skills/matcha/)** | Delegates a bounded task to a headless Claude Code run on the Matcha gateway, billed to that account per token instead of your subscription. Read only by default, `--write` opts into edits | Second opinion, offloading bulk work, or continuing after your subscription window runs out |
 
 </details>
 
@@ -669,11 +670,11 @@ sequenceDiagram
     Claude-->>You: "Bug fixed, types clean"
 ```
 
-**28 hook scripts included.** 11 are auto-wired when you install the playbook as a plugin (via [hooks/hooks.json](hooks/hooks.json)); the rest are opt-in via your `settings.json`.
+**31 hook scripts included.** 11 are auto-wired when you install the playbook as a plugin (via [hooks/hooks.json](hooks/hooks.json)); the rest are opt-in via your `settings.json`.
 
 **Auto-wired (11):** [session-start-check.sh](hooks/session-start-check.sh) (environment validation) · [pre-commit-guard.sh](hooks/pre-commit-guard.sh) (debug statements) · [env-guard.sh](hooks/env-guard.sh) (secrets) · [firewall.sh](hooks/firewall.sh) (dangerous command blocker) · [protect-paths.sh](hooks/protect-paths.sh) (protected file guard) · [ts-check.sh](hooks/ts-check.sh) (type errors) · [lint-check.sh](hooks/lint-check.sh) (ESLint) · [format-check.sh](hooks/format-check.sh) (Prettier) · [build-check.sh](hooks/build-check.sh) (OOM-safe builds) · [daydream.sh](hooks/daydream.sh) (idle memory → ideas → quick PRD) · [daydream-surface.sh](hooks/daydream-surface.sh) (surface daydreams at session start)
 
-**Opt-in (17):** [verify-gate.sh](hooks/verify-gate.sh) (Stop-blocking verify gate with baseline diffing) · [audit-log.sh](hooks/audit-log.sh) (raw-prompt compliance log) · [secret-scanner.py](hooks/secret-scanner.py) (pattern-based secret detection) · [codex-prepush-review.sh](hooks/codex-prepush-review.sh) (second-model review on push) · [pre-commit-verify.sh](hooks/pre-commit-verify.sh) (typecheck before commit) · [commit-message-check.sh](hooks/commit-message-check.sh) (conventional commits) · [tdd-gate.sh](hooks/tdd-gate.sh) (warn on source edits without a failing test) · [plan-gate.sh](hooks/plan-gate.sh) (warn on edits without a plan) · [require-agent-model.sh](hooks/require-agent-model.sh) (block subagent spawns without an explicit model) · [research-only-guard.sh](hooks/research-only-guard.sh) (enforce analysis-only mode) · [test-on-save.sh](hooks/test-on-save.sh) (auto-run relevant tests) · [auto-simplify.sh](hooks/auto-simplify.sh) (simplification pass on commit) · [stop-handoff.sh](hooks/stop-handoff.sh) (write a "where I left off" handoff) · [sessionstart-handoff.sh](hooks/sessionstart-handoff.sh) (re-inject the last handoff) · [precompact-handoff.sh](hooks/precompact-handoff.sh) (preserve state before compaction) · [notify-local-tts.sh](hooks/notify-local-tts.sh) (TTS notifications) · [play-tts.sh](hooks/play-tts.sh) (TTS wrapper)
+**Opt-in (20):** [verify-gate.sh](hooks/verify-gate.sh) (Stop-blocking verify gate with baseline diffing) · [audit-log.sh](hooks/audit-log.sh) (raw-prompt compliance log) · [secret-scanner.py](hooks/secret-scanner.py) (pattern-based secret detection) · [codex-prepush-review.sh](hooks/codex-prepush-review.sh) (second-model review on push) · [pre-commit-verify.sh](hooks/pre-commit-verify.sh) (typecheck before commit) · [commit-message-check.sh](hooks/commit-message-check.sh) (conventional commits) · [tdd-gate.sh](hooks/tdd-gate.sh) (warn on source edits without a failing test) · [plan-gate.sh](hooks/plan-gate.sh) (warn on edits without a plan) · [require-agent-model.sh](hooks/require-agent-model.sh) (block subagent spawns without an explicit model) · [research-only-guard.sh](hooks/research-only-guard.sh) (enforce analysis-only mode) · [test-on-save.sh](hooks/test-on-save.sh) (auto-run relevant tests) · [auto-simplify.sh](hooks/auto-simplify.sh) (simplification pass on commit) · [stop-handoff.sh](hooks/stop-handoff.sh) (write a "where I left off" handoff) · [sessionstart-handoff.sh](hooks/sessionstart-handoff.sh) (re-inject the last handoff) · [precompact-handoff.sh](hooks/precompact-handoff.sh) (preserve state before compaction) · [notify-local-tts.sh](hooks/notify-local-tts.sh) (TTS notifications) · [play-tts.sh](hooks/play-tts.sh) (TTS wrapper) · [matcha-review.sh](hooks/matcha-review.sh) (second reviewer on the working diff, via Matcha, read only) · [matcha-surface.sh](hooks/matcha-surface.sh) (surfaces the Matcha review, warns when subscription quota is nearly gone) · [matcha-offload-gate.sh](hooks/matcha-offload-gate.sh) (blocks cheap subagent spawns under quota pressure, points them at Matcha)
 
 > See **[hooks/README.md](hooks/README.md)** for setup and **[config/hooks-example.json](config/hooks-example.json)** for an example configuration wiring 9 of the hook scripts.
 

--- a/docs/matcha-lane.md
+++ b/docs/matcha-lane.md
@@ -1,0 +1,54 @@
+---
+title: Matcha Lane
+parent: Advanced
+nav_order: 10
+---
+# Matcha Lane
+
+Matcha is an internal, Anthropic compatible API gateway. The matcha lane runs the real Claude Code binary headless against it, so a delegated task gets a full agent with file access, not a single chat completion. Cost lands on the gateway account per token, not on your Claude subscription. It is read only by default, and `--write` opts it into editing files.
+
+Three hooks sit around it: one reviews your working diff when a turn ends, one surfaces the findings and warns when your subscription quota is nearly gone, and one blocks cheap subagent spawns under quota pressure and points them at the gateway instead.
+
+## What It Is
+
+The [matcha skill](../skills/matcha/) wraps `matcha-run.sh`, a script that launches `claude` in restricted mode against the gateway with a bounded prompt, a budget cap, and a timeout. Same shape as the Codex delegation lane described in [Multi-Model Orchestration](multi-model-orchestration.md): send a bounded slice of work, keep working yourself, collect the answer when it lands. The model tier (fast, standard, deep) is picked automatically from whatever the gateway reports as current, never named from memory.
+
+Because the run is a full agent, it can read, grep, and glob inside a working directory you point it at. With `--write` it can also edit and use a shell there, still confined to that directory.
+
+## When To Reach For It
+
+Use the lane, rather than doing the work in this session, when:
+
+- You want a second, independent reviewer on a diff before calling something done.
+- The task is bounded and mechanical enough to hand off with a short prompt (a review, a diagnosis, a bulk edit), and you would rather keep your own context for judgement and orchestration.
+- Your subscription window is close to its limit and the task can be pushed off it onto the gateway instead.
+
+It is the wrong tool for a one-line lookup (the plain `matcha "prompt"` command is cheaper, since it is a single API call with no tools), for anything the user specifically asked to send through Codex, and for work that needs this conversation's context, since the delegate starts with no memory of it.
+
+## Read Only By Default, And Why That Matters
+
+`matcha-run.sh` reads, greps, and globs inside the working directory and nothing else, unless `--write` is passed. This matters for two reasons:
+
+1. A review or diagnosis has no reason to touch files. Keeping it read only means a mistake in the prompt cannot turn into an unwanted edit.
+2. A `--write` run is real risk: it edits a real working directory. Before one runs, the directory should be a git checkout with current work committed or stashed, so the edits are reviewable as a diff and reversible, and it should never be pointed at a checkout another session is actively using.
+
+The nested run also ignores your own hooks on purpose, because it launches in restricted mode. Without that, your hooks would fire inside the delegate and block its own allowed tools.
+
+## The Three Hooks
+
+| Hook | Point | What it does |
+|------|-------|---------------|
+| [matcha-review.sh](../hooks/matcha-review.sh) | `Stop` | When a turn ends, sends the working diff to the gateway for an independent, read only review, in the background. Skips diffs that are too small to be worth it or too large for the delegate to hold, keeps a daily spend ceiling, and never blocks the stop. |
+| [matcha-surface.sh](../hooks/matcha-surface.sh) | `UserPromptSubmit` | On your next prompt, delivers any review that finished since the last one, and checks your subscription usage. If the window is nearly spent it tells you to route heavy work through the gateway instead of doing it here. |
+| [matcha-offload-gate.sh](../hooks/matcha-offload-gate.sh) | `PreToolUse` on `Agent` | Under real quota pressure, blocks a cheap subagent spawn (Haiku or Sonnet tier) and points the caller at `matcha-run.sh` instead, so mechanical subagent work stops competing with the session for what is left of the subscription window. Fails open on any error, and can be bypassed with `MATCHA_OFFLOAD_OK=1`. |
+
+## Honest Limits
+
+The two quota aware hooks, `matcha-surface.sh` and `matcha-offload-gate.sh`, only work if something outside Claude Code is writing a usage sampler file (a record of how much of the five hour and seven day subscription window has been used). Claude Code does not ship that sampler. Without it, both hooks read nothing, find nothing, and exit quietly: no warning, no gate, no error. They are not broken in that state, they are simply inert, and nothing in a normal session will tell you that.
+
+`matcha-review.sh` has no such dependency: it only needs a git repository and a working diff, so it runs on its own once installed.
+
+## See Also
+
+- [Multi-Model Orchestration](multi-model-orchestration.md), for the Codex delegation lane this one is modelled on.
+- [Cost and Observability](cost-and-observability.md), for tracking what a delegate run actually costs.

--- a/hooks/matcha-offload-gate.sh
+++ b/hooks/matcha-offload-gate.sh
@@ -1,0 +1,50 @@
+#!/usr/bin/env bash
+# matcha-offload-gate - PreToolUse on Agent. When the subscription window is
+# nearly spent, cheap mechanical subagent work stops being free and starts
+# being the thing that ends the session early. This blocks those spawns and
+# points them at Matcha, which bills Harris instead.
+#
+# Deliberately narrow: only fires when the window is genuinely nearly gone, and
+# only on cheap-tier agents. Judgment work on the top tier still runs here.
+# Fails open on any error. Bypass with MATCHA_OFFLOAD_OK=1.
+payload="$(cat 2>/dev/null)"
+[[ -n "$payload" ]] || exit 0
+[[ "${MATCHA_OFFLOAD_OK:-0}" == "1" ]] && exit 0
+[[ -n "$CLAUDE_SKIP_HOOKS" && "$CLAUDE_SKIP_HOOKS" == *matcha* ]] && exit 0
+
+model="$(printf '%s' "$payload" | jq -r '.tool_input.model // ""' 2>/dev/null)"
+[[ "$model" == "haiku" || "$model" == "sonnet" ]] || exit 0
+
+verdict="$(python3 - <<'PY' 2>/dev/null
+import json, os, time
+p = os.path.expanduser("~/.claude/usage-history.jsonl")
+try:
+    if time.time() - os.path.getmtime(p) > 1800:
+        raise SystemExit
+    with open(p, "rb") as fh:
+        fh.seek(max(0, os.path.getsize(p) - 4000))
+        last = fh.read().decode("utf-8", "replace").strip().splitlines()[-1]
+    d = json.loads(last)
+    five = d.get("five_hour", {}).get("used_percentage", 0)
+    week = d.get("seven_day", {}).get("used_percentage", 0)
+except Exception:
+    raise SystemExit
+if week >= 92 or five >= 90:
+    print("%d %d" % (five, week))
+PY
+)"
+[[ -n "$verdict" ]] || exit 0
+five="${verdict%% *}"; week="${verdict##* }"
+
+cat >&2 <<EOF
+matcha offload gate: subscription at ${five}% of the 5 hour window and ${week}% of the week.
+A ${model} subagent is exactly the work that should not be spending what is left.
+
+Send this task to Matcha instead (billed to Harris, not the subscription):
+  ~/.claude/scripts/matcha-run.sh --tier $( [[ "$model" == haiku ]] && echo fast || echo standard ) "<the task, with all the context the delegate needs>"
+Add --write only if the task genuinely has to edit files.
+
+Keep judgment, orchestration and anything needing this conversation's context here.
+If this really must run locally, MATCHA_OFFLOAD_OK=1 must be exported before the session started.
+EOF
+exit 2

--- a/hooks/matcha-review.sh
+++ b/hooks/matcha-review.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# matcha-review - Stop hook. Sends the working diff to Matcha for an
+# independent read-only review, in the background, billed to Harris rather
+# than the subscription. Never blocks the stop, never edits anything.
+#
+# Findings are not printed here (the turn is already over). They are picked up
+# by matcha-surface.sh on the next prompt, so nothing has to be remembered.
+exec 2>/dev/null
+[[ -n "$CLAUDE_SKIP_HOOKS" && "$CLAUDE_SKIP_HOOKS" == *matcha* ]] && exit 0
+
+STATE="$HOME/.claude/.matcha-review"
+mkdir -p "$STATE"
+
+CWD="$(pwd)"
+git -C "$CWD" rev-parse --git-dir >/dev/null 2>&1 || exit 0
+REPO="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)" || exit 0
+KEY="$(printf '%s' "$REPO" | shasum | cut -c1-12)"
+
+DIFF="$(git -C "$REPO" diff HEAD 2>/dev/null)"
+[[ -n "$DIFF" ]] || exit 0
+
+LINES=$(printf '%s' "$DIFF" | wc -l | tr -d ' ')
+# Below 15 changed lines there is nothing worth 20p. Above 3000 the prompt
+# costs more than the review is worth and the delegate loses the thread.
+[[ $LINES -lt 15 || $LINES -gt 3000 ]] && exit 0
+
+HASH="$(printf '%s' "$DIFF" | shasum | cut -c1-16)"
+[[ -f "$STATE/$KEY.hash" && "$(cat "$STATE/$KEY.hash")" == "$HASH" ]] && exit 0
+
+# Daily spend ceiling. A stop hook that fires all day is how a delegate quietly
+# runs up a bill nobody authorised.
+TODAY="$(date +%Y-%m-%d)"
+SPENT_F="$STATE/spend-$TODAY"
+[[ -f "$SPENT_F" ]] || echo 0 > "$SPENT_F"
+COUNT="$(cat "$SPENT_F")"
+CEILING="${MATCHA_REVIEW_DAILY_MAX:-12}"
+[[ $COUNT -ge $CEILING ]] && exit 0
+echo $((COUNT + 1)) > "$SPENT_F"
+
+printf '%s' "$HASH" > "$STATE/$KEY.hash"
+OUT="$STATE/$KEY.findings"
+BRANCH="$(git -C "$REPO" rev-parse --abbrev-ref HEAD 2>/dev/null)"
+
+PROMPT="You are a second reviewer on a working diff. Another reviewer has already seen it, so only report what a careful reader would still flag.
+
+Repo: $(basename "$REPO")   Branch: $BRANCH
+You can read the surrounding source in this directory for context. Do not suggest edits, do not rewrite code.
+
+Look for: logic that is wrong for a real input, a case the change does not handle, state that can be observed half updated, an assumption the surrounding code does not actually hold, and anything the diff claims in a comment or message that the code does not do.
+
+Ignore: style, naming, formatting, test coverage as a topic, and anything you cannot tie to a concrete failing input.
+
+Output strictly: one line VERDICT, then at most 5 bullets, each naming the input or condition and what breaks. If nothing is worth raising, reply with exactly: CLEAN.
+
+--- DIFF ---
+$DIFF"
+
+nohup "$HOME/.claude/scripts/matcha-run.sh" --dir "$REPO" --tier deep \
+  --budget 0.60 --timeout 540 "$PROMPT" > "$OUT.tmp" 2>"$OUT.log" \
+  && mv "$OUT.tmp" "$OUT" &
+disown 2>/dev/null
+exit 0

--- a/hooks/matcha-surface.sh
+++ b/hooks/matcha-surface.sh
@@ -1,0 +1,63 @@
+#!/usr/bin/env bash
+# matcha-surface - UserPromptSubmit hook. Two jobs, both about not making you
+# remember anything:
+#   1. Deliver any Matcha review that finished since the last prompt.
+#   2. Warn when the subscription window is nearly spent, and say what to do.
+exec 2>/dev/null
+[[ -n "$CLAUDE_SKIP_HOOKS" && "$CLAUDE_SKIP_HOOKS" == *matcha* ]] && exit 0
+
+STATE="$HOME/.claude/.matcha-review"
+mkdir -p "$STATE"
+
+# --- 1. finished reviews -------------------------------------------------
+CWD="$(pwd)"
+if REPO="$(git -C "$CWD" rev-parse --show-toplevel 2>/dev/null)"; then
+  KEY="$(printf '%s' "$REPO" | shasum | cut -c1-12)"
+  F="$STATE/$KEY.findings"
+  SEEN="$STATE/$KEY.seen"
+  if [[ -f "$F" ]] && { [[ ! -f "$SEEN" ]] || [[ "$F" -nt "$SEEN" ]]; }; then
+    BODY="$(cat "$F")"
+    if [[ -n "$BODY" && "$BODY" != *CLEAN* ]]; then
+      printf '%s\n' "MATCHA SECOND REVIEW of the working diff in $(basename "$REPO"). Independent reader, read only, no edits made."
+      printf '%s\n' "VISIBILITY IS MANDATORY: the user cannot see this text. Open your very next reply to them with a line that starts 'Matcha reviewed the diff:' and give them the verdict and what you are doing about it. Do not silently absorb it, and do not defer it to a later turn."
+      printf '%s\n' "Treat every bullet as a claim to verify against the code first. Say which ones held up and which did not."
+      printf '%s\n' "$BODY"
+    fi
+    touch "$SEEN"
+  fi
+fi
+
+# --- 2. subscription headroom -------------------------------------------
+python3 - <<'PY'
+import json, os, time
+p = os.path.expanduser("~/.claude/usage-history.jsonl")
+try:
+    if time.time() - os.path.getmtime(p) > 1800:
+        raise SystemExit
+    with open(p, "rb") as fh:
+        fh.seek(max(0, os.path.getsize(p) - 4000))
+        last = fh.read().decode("utf-8", "replace").strip().splitlines()[-1]
+    d = json.loads(last)
+    five = d.get("five_hour", {}).get("used_percentage", 0)
+    week = d.get("seven_day", {}).get("used_percentage", 0)
+except Exception:
+    raise SystemExit
+
+if week >= 99 or five >= 99:
+    print(
+        "MATCHA TAKEOVER ARMED: subscription at %d%% of the 5 hour window and %d%% of the week. "
+        "When this session hits the wall it will relaunch itself on Matcha and carry on, so do "
+        "not warn the user that work is about to be lost. Route everything you can through "
+        "~/.claude/scripts/matcha-run.sh now rather than spending the last of the window here. "
+        "Tell him once, in one line, that the takeover is armed." % (five, week)
+    )
+elif week >= 90 or five >= 85:
+    print(
+        "MATCHA OFFLOAD: subscription at %d%% of the 5 hour window and %d%% of the week. "
+        "Push heavy or bulk work off it now: run it through ~/.claude/scripts/matcha-run.sh "
+        "(the matcha skill) instead of doing it here or spawning a subagent. "
+        "That spend lands on the Harris account, not the user's limit. "
+        "Keep judgment and orchestration in this session." % (five, week)
+    )
+PY
+exit 0

--- a/index.md
+++ b/index.md
@@ -18,10 +18,10 @@ Built at **Harris Computer** · Part of **Constellation Software**
 
 | Category | Count | Description |
 |----------|-------|-------------|
-| [Skills](docs/skills-ecosystem) | 47 | Production-ready custom `/commands` you can drop into any project |
+| [Skills](docs/skills-ecosystem) | 48 | Production-ready custom `/commands` you can drop into any project |
 | [Templates](templates/CLAUDE) | 11 | Stack-specific CLAUDE.md files for TypeScript, React, Node, Python, Go, Rust, and more — plus a team onboarding template |
-| [Hooks](hooks/) | 28 | Guard-rail scripts for commits, builds, secrets, and session state — 11 auto-wired via the plugin, the rest opt-in |
-| [Docs](docs/guide) | 71 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 59 news deep-reads |
+| [Hooks](hooks/) | 31 | Guard-rail scripts for commits, builds, secrets, and session state — 11 auto-wired via the plugin, the rest opt-in |
+| [Docs](docs/guide) | 72 | Guides, patterns, anti-patterns, troubleshooting, and reference material — plus 59 news deep-reads |
 | [Examples](examples/) | 5 | Annotated real-world sessions showing workflows in action |
 | [Onboarding](onboarding/) | 6 | Step-by-step guides from installation to advanced usage |
 

--- a/skills/matcha/SKILL.md
+++ b/skills/matcha/SKILL.md
@@ -1,0 +1,98 @@
+---
+name: matcha
+description: Delegate a bounded task to an agentic Claude run on the Harris Matcha gateway, the way the codex plugin delegates to Codex. Runs headless in the background, reads the repo, and with --write edits it, billed to Matcha per token instead of the user's subscription. Use when the user says "/matcha", "send it to matcha", "matcha this", "delegate to matcha", "second opinion from matcha", "have matcha review this", "run that on matcha", "offload this", or when the subscription is close to its limit and work can be pushed off it. Do NOT use for a one-line lookup (the plain `matcha "prompt"` command is cheaper), for image generation (that is imagegen), or as a substitute for a Codex review when the user specifically asked for Codex.
+---
+
+# Delegating to Matcha
+
+Matcha is a Harris internal Anthropic passthrough. This skill runs the real
+Claude Code binary headless against it, so the delegate is a full agent with
+file access, not a single chat completion. Same rhythm as the Codex lane: send
+a bounded slice, keep working, collect the answer.
+
+Cost lands on the Harris Matcha account per token, not on your subscription.
+That is the whole point, and also the reason every run is capped.
+
+## The command
+
+```
+~/.claude/scripts/matcha-run.sh [--write] [--tier deep|standard|fast] \
+  [--dir PATH] [--budget USD] [--timeout SEC] "task"
+```
+
+Read only by default. It can read, grep and glob inside the working directory
+and nothing else. `--write` adds editing and shell, still confined to that
+directory.
+
+## Choosing the tier
+
+The model is picked automatically: the script asks the gateway what is live
+today and takes the newest generation in the tier's family. Never pass
+`--model` unless the user names one. Never type a model id from memory, the
+gateway reports a wrong name as a server error and the client retries it for
+minutes before giving up.
+
+| Tier | Family | Send it |
+|------|--------|---------|
+| `deep` (default) | Opus | review, diagnosis, architecture, anything needing judgment |
+| `standard` | Sonnet | implementation, mechanical bulk edits, refactors |
+| `fast` | Haiku | search, extraction, summarising a pile of files |
+
+## How to run it
+
+Run it in the background and carry on. Do not sit and watch it.
+
+1. Confirm the working directory holds the code the task is about. The run
+   cannot see outside it.
+2. For a review or diagnosis, put the evidence where the delegate can read it.
+   It has no shell in read mode, so a diff has to be written to a file in the
+   working directory first, not fetched by the delegate.
+3. Launch with `run_in_background`.
+4. Collect when it lands. It prints the answer on stdout, and the cost, turn
+   count and error flag on stderr.
+
+## Writing the task
+
+The delegate has no memory of this conversation. Everything it needs goes in
+the prompt: what the code is for, what to look at, what a good answer looks
+like. A bare "review this" gets a bare review.
+
+Bound the output the same way subagent prompts are bounded: a verdict plus at
+most five bullets, no full body. An unbounded prompt on Opus is how a delegate
+costs a pound instead of five pence.
+
+## Before a --write run
+
+Writing is the mode that can hurt. Check both before launching:
+
+- The working directory is a git checkout with the current work committed or
+  stashed, so the delegate's edits are reviewable as a diff and reversible.
+- The user asked for edits. If they asked for an opinion, a review or a
+  diagnosis, stay read only.
+
+Never point a write run at a shared checkout another session is using. Use a
+worktree, the same rule as any other multi-session work.
+
+## After a write run
+
+Read the diff yourself before telling the user it is done. The delegate's report of
+what it did is a claim, not evidence. Run the project's own checks.
+
+## Gotchas
+
+- **The nested run ignores your hooks on purpose.** It is launched in
+  restricted mode, which skips the user and project settings files. Without
+  that, your hooks fire inside the delegate and block its own allowed tools,
+  which is what broke the earlier headless bots. Do not "fix" this by
+  re-enabling them.
+- **Bypass permissions is refused in restricted mode.** If a run dies
+  immediately saying so, something is passing a permission mode through the
+  environment. The script scrubs the inherited session variables for this
+  reason.
+- **`matcha` and `matcha-run.sh` are different things.** `matcha "prompt"` is
+  one API call with no tools and a short cap, right for a quick question.
+  This skill is the agentic one.
+- **A killed run exits 124.** That is the wall clock cap, not a crash. The
+  partial log path is on stderr.
+- **No timeout command on this Mac.** The script carries its own watchdog, so
+  do not wrap it in `timeout` or `gtimeout`, neither exists here.

--- a/skills/matcha/matcha-run.sh
+++ b/skills/matcha/matcha-run.sh
@@ -1,0 +1,166 @@
+#!/bin/zsh
+# matcha-run - delegate an AGENTIC task to the Harris Matcha gateway.
+#
+# Unlike matcha.sh (one API call, no tools) this runs the real Claude Code
+# binary headless against Matcha, so it can read the repo, grep it and, with
+# --write, edit it. The Codex shape, different engine, billed to Matcha.
+#
+# Usage:
+#   matcha-run.sh [opts] "task"
+#     --write            allow Edit/Write/Bash in the working dir (default: read only)
+#     --tier deep|standard|fast   default deep
+#     --dir PATH         working dir (default: cwd)
+#     --budget USD       spend cap (default 2.00)
+#     --timeout SEC      wall clock cap (default 900)
+#     --model NAME       force a model, skips auto selection
+#
+# Exit 0 = task finished. Non-zero = config problem, timeout or run error.
+
+CFG="$HOME/.claude/matcha.env"
+CACHE="$HOME/.claude/.matcha-models.json"
+[[ -r "$CFG" ]] || { print -u2 "matcha-run: missing $CFG"; exit 1; }
+source "$CFG"
+KEY="$(security find-generic-password -a "$USER" -s matcha-api-key -w 2>/dev/null)" \
+  || { print -u2 "matcha-run: key not in keychain (service: matcha-api-key)"; exit 1; }
+
+WRITE=0; TIER=deep; DIR="$PWD"; BUDGET=2.00; TIMEOUT=900; FORCE_MODEL=""
+typeset -a WORDS
+need() { [[ $# -ge 2 ]] || { print -u2 "matcha-run: $1 needs a value"; exit 1; }; }
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --write)   WRITE=1; shift ;;
+    --tier)    need "$@"; TIER="$2"; shift 2 ;;
+    --dir)     need "$@"; DIR="$2"; shift 2 ;;
+    --budget)  need "$@"; BUDGET="$2"; shift 2 ;;
+    --timeout) need "$@"; TIMEOUT="$2"; shift 2 ;;
+    --model)   need "$@"; FORCE_MODEL="$2"; shift 2 ;;
+    --) shift; WORDS+=("$@"); break ;;
+    -*) print -u2 "matcha-run: unknown flag $1"; exit 1 ;;
+    # A flag written after the task must still be honoured, not swallowed into
+    # the prompt text, so keep scanning instead of breaking here.
+    *) WORDS+=("$1"); shift ;;
+  esac
+done
+TASK="${WORDS[*]}"
+case "$TIER" in
+  deep|standard|fast) ;;
+  *) print -u2 "matcha-run: unknown tier '$TIER' (deep, standard or fast)"; exit 1 ;;
+esac
+# A bad number here would otherwise fire the watchdog instantly and be reported
+# as a real timeout, which sends you hunting a hang that never happened.
+[[ "$TIMEOUT" == <-> ]] || { print -u2 "matcha-run: --timeout must be whole seconds, got '$TIMEOUT'"; exit 1; }
+[[ "$BUDGET" =~ '^[0-9]+(\.[0-9]+)?$' ]] || { print -u2 "matcha-run: --budget must be a number, got '$BUDGET'"; exit 1; }
+[[ -n "$TASK" ]] || { print -u2 "matcha-run: no task given"; exit 1; }
+[[ -d "$DIR" ]]  || { print -u2 "matcha-run: no such directory: $DIR"; exit 1; }
+
+# --- live model list ------------------------------------------------------
+# Never guess a deployment name: ask the gateway. Cached for a day, because a
+# wrong name is reported as HTTP 500 and retried with backoff, which hangs.
+refresh_models() {
+  curl -s -m 30 "$MATCHA_BASE_URL/v1/models/" \
+    -H "MATCHA-API-KEY: $KEY" -H "anthropic-version: 2023-06-01" > "$CACHE.tmp" 2>/dev/null
+  if python3 -c 'import json,sys; d=json.load(open(sys.argv[1])); assert d.get("data")' "$CACHE.tmp" 2>/dev/null; then
+    mv "$CACHE.tmp" "$CACHE"; return 0
+  fi
+  rm -f "$CACHE.tmp"; return 1
+}
+CACHE_AGE=999999
+[[ -f "$CACHE" ]] && CACHE_AGE=$(( $(date +%s) - $(stat -f %m "$CACHE") ))
+if [[ $CACHE_AGE -gt 86400 ]]; then
+  if refresh_models; then
+    CACHE_AGE=0
+  elif [[ -f "$CACHE" ]]; then
+    # Stale but present is the common failure (VPN down). Say so out loud, and
+    # refuse outright once it is old enough that the model list is a guess.
+    if [[ $CACHE_AGE -gt 604800 ]]; then
+      print -u2 "matcha-run: gateway unreachable and the model list is over a week old. Refusing to guess."
+      exit 1
+    fi
+    print -u2 "matcha-run: gateway unreachable, using a model list $(( CACHE_AGE / 3600 ))h old."
+  fi
+fi
+[[ -f "$CACHE" ]] || { print -u2 "matcha-run: cannot reach gateway to list models (VPN? gateway down?)"; exit 1; }
+
+# Auto selection: newest generation that is actually live in the tier's family.
+# Adding a newer model to the gateway upgrades this with no edit here.
+pick_model() {
+  python3 - "$CACHE" "$1" <<'PY'
+import json, re, sys
+ids = [m["id"] for m in json.load(open(sys.argv[1]))["data"]]
+fam = {"deep": "opus", "standard": "sonnet", "fast": "haiku"}.get(sys.argv[2], "opus")
+# ranked by (major, minor) descending, so claude-opus-5 beats claude-opus-4-6
+def ver(i):
+    tail = i.split(fam, 1)[1] if fam in i else ""
+    nums = [int(x) for x in re.findall(r"\d+", tail)]
+    # Drop trailing date stamps like -20251001, otherwise a legacy dated
+    # deployment sorts above every real version and gets picked silently.
+    nums = [n for n in nums if n < 100000]
+    return tuple(nums) if nums else (0,)
+cand = sorted([i for i in ids if fam in i], key=ver, reverse=True)
+print(cand[0] if cand else "")
+PY
+}
+if [[ -n "$FORCE_MODEL" ]]; then MODEL="$FORCE_MODEL"; else MODEL="$(pick_model "$TIER")"; fi
+SMALL="$(pick_model fast)"
+[[ -n "$MODEL" ]] || { print -u2 "matcha-run: no model in tier '$TIER' on this gateway"; exit 1; }
+[[ -n "$SMALL" ]] || SMALL="$MODEL"
+
+# Prove the pick is a real deployment before handing over, else a 500 storm.
+"$HOME/.claude/scripts/matcha-preflight.sh" "$MODEL" || exit 1
+
+# --- tools ----------------------------------------------------------------
+# --restricted drops the code-running tools AND ignores user/project/local
+# settings, so your hooks never fire inside the nested run. It also confines
+# the file tools to the working directory.
+if [[ $WRITE -eq 1 ]]; then
+  TOOLS="Read,Grep,Glob,Edit,Write,Bash"
+  PERM="acceptEdits"
+else
+  TOOLS="Read,Grep,Glob"
+  PERM="default"
+fi
+
+# Log goes to a temp dir, never into $DIR: a stray .matcha-run.json in a repo
+# shows up in git status and gets committed by accident.
+LOGDIR="${TMPDIR:-/tmp}/matcha-run"
+mkdir -p "$LOGDIR"
+LOG="${MATCHA_RUN_LOG:-$LOGDIR/$(date +%Y%m%d-%H%M%S)-$$.json}"
+print -u2 "matcha-run: model=$MODEL tier=$TIER write=$WRITE budget=\$$BUDGET timeout=${TIMEOUT}s dir=$DIR"
+
+cd "$DIR" || exit 1
+env -u CLAUDECODE -u CLAUDE_CODE_ENTRYPOINT -u CLAUDE_CODE_SESSION_ID \
+    -u CLAUDE_CODE_CHILD_SESSION -u CLAUDE_CODE_MESSAGING_SOCKET \
+    -u CLAUDE_CODE_MESSAGING_TOKEN -u CLAUDE_CODE_BRIDGE_SESSION_ID \
+    -u CLAUDE_PID -u CLAUDE_EFFORT -u CODEX_COMPANION_TRANSCRIPT_PATH \
+    -u CLAUDE_PLUGIN_DATA -u ANTHROPIC_API_KEY \
+    ANTHROPIC_BASE_URL="$MATCHA_BASE_URL" ANTHROPIC_AUTH_TOKEN="$KEY" \
+    ANTHROPIC_MODEL="$MODEL" ANTHROPIC_SMALL_FAST_MODEL="$SMALL" \
+    claude -p "$TASK" --restricted --tools "$TOOLS" --strict-mcp-config \
+      --permission-mode "$PERM" --output-format json --max-budget-usd "$BUDGET" \
+      > "$LOG" 2>"$LOG.err" &
+RUN_PID=$!
+( sleep "$TIMEOUT"; kill -TERM $RUN_PID 2>/dev/null ) &
+WATCHDOG=$!
+wait $RUN_PID; RC=$?
+kill $WATCHDOG 2>/dev/null
+
+if [[ $RC -eq 143 || $RC -eq 137 ]]; then
+  print -u2 "matcha-run: killed at the ${TIMEOUT}s wall clock cap. Partial log: $LOG"
+  exit 124
+fi
+
+python3 - "$LOG" "$LOG.err" "$RC" <<'PY'
+import json, sys, os
+log, errf, rc = sys.argv[1], sys.argv[2], int(sys.argv[3])
+try:
+    d = json.load(open(log))
+except Exception:
+    err = open(errf).read() if os.path.exists(errf) else ""
+    sys.stderr.write("matcha-run: no usable result.\n" + err[-800:] + "\n"); sys.exit(1)
+print(d.get("result", ""))
+sys.stderr.write("matcha-run: cost $%.4f, %s turns, error=%s\n"
+                 % (d.get("total_cost_usd") or 0, d.get("num_turns"), d.get("is_error")))
+# The run's own exit code counts too: a crash after valid JSON was
+# otherwise reported as a clean finish.
+sys.exit(1 if (d.get("is_error") or rc != 0) else 0)
+PY


### PR DESCRIPTION
## What this adds

A second delegation lane alongside the existing Codex one. Matcha is an Anthropic compatible gateway; this runs the real Claude Code binary headless against it, so a delegated task gets a full agent with file access rather than a single chat completion. Cost lands on the gateway account per token instead of the subscription.

- `skills/matcha` wraps `matcha-run.sh` with a per run budget cap and a timeout. Read only by default, `--write` opts into editing.
- `matcha-review.sh` (Stop) sends the working diff for an independent read only second review, in the background, capped at 12 a day.
- `matcha-surface.sh` (UserPromptSubmit) delivers that review on the next prompt and warns when the subscription window is nearly spent.
- `matcha-offload-gate.sh` (PreToolUse on Agent) blocks cheap subagent spawns under quota pressure and points them at the gateway. Fails open.
- `docs/matcha-lane.md`, plus the badge and table counts.

## Notes for review

The three hooks are bash, not zsh, so they pass this repo's own hook validation and run on a plain bash machine. The one behaviour change that came out of that: review text is now printed literally, so a backslash-n inside a finding stays as written rather than being expanded into a newline. That is the safer default for model generated prose.

The model tier is read from whatever the gateway reports as current rather than named in the file, so the guide cannot rot into a broken default.

## Verified

- Every `hooks/*.sh` passes the workflow's own shebang check, and `bash -n` is clean on all three new hooks.
- `matcha-surface.sh` and `matcha-offload-gate.sh` were run under bash against live usage data: the gate blocks a haiku spawn and passes an opus one through, and the surface hook prints a finding unmangled.
- No API keys anywhere. The key lives in the macOS keychain.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0174d91cBGzwEUXzZbVUuseJ